### PR TITLE
Default multi-source loop-closing in the daily briefing + setup wizard

### DIFF
--- a/docs/superpowers/specs/2026-06-04-default-multi-source-loop-closing-design.md
+++ b/docs/superpowers/specs/2026-06-04-default-multi-source-loop-closing-design.md
@@ -1,0 +1,180 @@
+# Design: default multi-source loop-closing + setup wizard
+
+**Date:** 2026-06-04
+**Status:** approved (implementing)
+**Branch:** `feat/default-multi-source-loop-closing`
+
+## Problem
+
+The vault's biggest silent-failure mode is **state lagging reality**: the user
+answers an email, posts a form in Slack, or finishes a meeting off-vault, and the
+typed note rots at its old status. Two skills already address this — `capture-comms`
+(scans Gmail sent+received and Slack sent+received, stages action items) and
+`reconcile-from-comms` (closes the loops) — but they are **manual, separate** skills
+that the user must remember to run. The daily briefing only has a weaker §0
+"State confirmation needed" pre-flight that *guesses* at stale state.
+
+The user wants the daily flow to, **by default**, check incoming + outgoing email,
+Slack, and calendar (and be extensible to other sources), so that responding to an
+email automatically reflects the completed work — and wants setup to (a) ask which
+streams they use and tell them how to grant access, and (b) offer a privacy-aware
+git mode.
+
+## Decisions (locked with the user)
+
+1. **Auto-close stance: A — keep the guardrail, with batching.** Reconcile
+   auto-applies only reversible bookkeeping (bump `last_contact`, mark a Followup
+   `acted_on`); task closes stay propose-only and are confirmed in one batch
+   ("yes to 1,3,4"). The "agents never self-close to `done`" hard-no is preserved.
+2. **Trigger model: inside `daily-briefing`.** Generating the briefing runs
+   capture + reconcile as a Step 0, in the user's authenticated session (avoids the
+   headless-auth gap that a cron job would hit). No new background infra.
+3. **Calendar role: minimal.** Only a Task explicitly linked to a calendar event
+   whose end-time has passed becomes a Tier-B "confirm close" item. No attendee
+   matching, no `last_contact` bumping.
+4. **Extensibility: three + config list + documented path.** Implement
+   email/Slack/calendar now; store enabled streams as an editable config note, not
+   hard-coded; document how to add a fourth source.
+
+## Architecture
+
+The briefing becomes the conductor; the existing skills stay the instruments.
+Nothing is duplicated — `daily-briefing` *drives* `capture-comms` and
+`reconcile-from-comms` inline (they are instruction-sets in the same session), so
+their schema / log / sensitivity discipline is preserved and both remain usable
+standalone.
+
+```
+/daily-briefing
+   └─ Step 0a: read _config/sources.md          → which streams are enabled
+   └─ Step 0b: run capture-comms (enabled only)  → Inbox/comms/<date>/ refreshed
+   └─ Step 0c: run reconcile-from-comms          → Tier-A auto-applied (reversible);
+   │                                                Tier-B collected, NOT applied
+   └─ §0 "State confirmation needed" = reconcile Tier-B ∪ stale-state queries (deduped)
+   └─ Steps 1–13: synthesis (tasks closed in 0c already reflect reality)
+   └─ Report-back: single batched confirm → close-task for confirmed items
+```
+
+## Components
+
+### A. Config seam — `_config/sources.md` (new, tracked)
+
+Low-sensitivity note recording which streams the daily flow checks; read by
+`capture-comms`, `reconcile-from-comms`, and `daily-briefing`. Editable by hand
+post-init (no re-init needed to flip a stream).
+
+```yaml
+---
+type: config
+scope: sources
+git_mode: local            # local | none | remote (recorded for reference)
+updated: <YYYY-MM-DD>
+streams:
+  email:    { enabled: true,  mcp: claude_ai_Gmail }
+  slack:    { enabled: true,  mcp: claude_ai_Slack }
+  calendar: { enabled: true,  mcp: claude_ai_Google_Calendar, mode: minimal }
+---
+```
+
+Body documents the "add a new source" extension path (config entry + a
+`capture-comms` scan block; reconcile needs no change since it reads the same
+`## Action items` API).
+
+**Backward compatibility:** if the file is absent (older vaults), skills assume
+`email + slack enabled, calendar planning-only` — nothing breaks.
+
+### B. Runtime — `daily-briefing` Step 0 orchestration
+
+Insert between the existence check (Step 1) and gather (Step 2):
+
+- Read `_config/sources.md`; no streams enabled / file absent → fall back to the
+  existing §0 stale-state queries only.
+- Run `capture-comms` for `<date>`, enabled streams only (it already handles a
+  per-source MCP outage gracefully).
+- Run `reconcile-from-comms` for `<date>` in **briefing sub-mode**: apply Tier-A
+  automatically; **do not prompt mid-briefing** for Tier-B — hand the proposals up.
+- §0 becomes **reconcile Tier-B ∪ the 4 stale-state queries** (deduped).
+- Report-back presents §0 as the single batched confirm; confirmed closes route
+  through `close-task`, then update reconcile's ledger/checkboxes.
+- **Backfill for a far-past `<date>`:** skip the comms refresh (a comms scan only
+  makes sense near today) and note it; generate from vault state.
+
+`reconcile-from-comms` gets a short "When invoked by daily-briefing" note documenting
+the defer-Tier-B-to-caller contract.
+
+### C. Calendar (minimal loop-closing)
+
+- `_schemas/task.md` gains optional `calendar_event_id:` and `calendar_event_title:`.
+- `create-task` persists the created event's id into `calendar_event_id` (it already
+  creates the event for time-blocked tasks).
+- Gated on `calendar.enabled`: open tasks carrying a `calendar_event_id` whose event
+  end-time has passed surface as a **Tier-B** "this meeting's time has passed — close
+  the task?" item in the same reconcile batch. Canceled/declined events → a
+  "reschedule or drop?" variant (the one stretch item).
+
+### D. Setup — `memex_init.py` interview additions
+
+After the existing placeholder questions:
+
+1. **Stream selection** — per-stream y/n (email/slack/calendar), default
+   `email,slack`. Non-interactive: optional `STREAMS` key in answers JSON
+   (list or comma-string); default `["email","slack"]`. Writes `_config/sources.md`
+   (added as a seed file; `_config/` added to `SCAFFOLD_DIRS`).
+2. **Access-grant instructions** — printed at the end (init cannot configure
+   claude.ai connectors, only instruct): connect each enabled stream's MCP connector;
+   capture stays empty but never errors until connected.
+3. **Git/privacy mode** — see E. Non-interactive: optional `GIT_MODE` key, default
+   `local`.
+
+`STREAMS` / `GIT_MODE` are **behavior answers**, read directly from the answers dict —
+NOT added to `placeholders.json` (which stays the audited `{{TOKEN}}` catalog).
+
+### E. Git/privacy modes
+
+Init's git-init step becomes conditional on `git_mode`:
+
+| Mode | Behavior | Warning printed |
+|---|---|---|
+| `local` (default) | `git init`, no remote (today's behavior) | — |
+| `none` | skip `git init` | "No version history: lose audit trail, time-travel, recovery." |
+| `remote` | `git init` + remote-setup guidance | Privacy warning ↓ |
+
+**Remote warning:** raw comms digests under `Inbox/` are already gitignored and never
+leave the machine — but reconciled facts (closed tasks, Person notes, Decisions) land
+in tracked notes and *would* push. Guidance: use a **private** repo; note that
+`sensitivity: sensitive` notes would sync. (Per-note gitignore-by-frontmatter is a
+known limitation — future work, not built now.)
+
+## What does NOT change (no regressions)
+
+- "Agents never self-close to `done`" hard-no (guardrail A).
+- Read-only on comms (never send/draft/react/schedule/mark-read).
+- Sensitivity handling (`private` summarized up; `sensitive` never quoted).
+- `Inbox/*` gitignored.
+
+## Files touched
+
+- `packs/core/skills/daily-briefing/SKILL.md` — Step 0 orchestration, §0 rewrite.
+- `packs/core/skills/reconcile-from-comms/SKILL.md` — briefing sub-mode + calendar Tier-B source.
+- `packs/core/skills/capture-comms/SKILL.md` — read `_config/sources.md`, gate streams.
+- `packs/core/skills/create-task/SKILL.md` — persist `calendar_event_id`.
+- `packs/core/schemas/task.md` — add `calendar_event_id` / `calendar_event_title`.
+- `tools/memex_init.py` — stream selection, git mode, `_config/sources.md` seed, access-grant printout.
+- `tools/test_memex_init.py`, `tests/test_init.sh`, `tests/fixtures/` — tests.
+- `hardened/contract/CLAUDE.base.md`, `hardened/contract/AGENTS.base.md` — document the default flow, `_config/sources.md`, git modes; add `capture-comms` + `reconcile-from-comms` rows; fix the stale "Out of scope: Slack capture" line.
+
+## Derive note
+
+The engine is normally *derived* from a source vault (`tools/derive.py`). These edits
+are made directly in the engine repo (the working copy the user PRs from); a future
+`derive.py` run from a source vault would need the same changes applied there too.
+The PR notes this.
+
+## Testing
+
+- `tools/test_memex_init.py` — unit tests for pure helpers (`parse_streams`,
+  `sources_config_yaml`).
+- `tests/test_init.sh` — assert `_config/sources.md` created with chosen streams; a
+  `GIT_MODE=none` fixture init produces no `.git`; default init still produces `.git`.
+- `python3 tools/audit_literals.py ./packs` and `./hardened` — must stay AUDIT CLEAN.
+- `(cd tools && python3 -m unittest)`.

--- a/hardened/contract/AGENTS.base.md
+++ b/hardened/contract/AGENTS.base.md
@@ -45,6 +45,7 @@ If your role is not declared at the start of a session, ask. Do not assume.
 | `Agents/` | all agents | jobs, runs, prompts (paste-able), approvals |
 | `Drafts/` | executors, librarian, user | git-tracked staging area for finalize-later text drafts (LLM prose, code, reports). Text is committed; heavy binaries are gitignored. Promote finished drafts into typed `Atlas/` notes, then archive/delete the draft. |
 | `outputs/` | executors | generated **binary** artifacts (report PDFs, letterhead `.docx`, CV PDFs). Folder + `README.md` tracked; contents (`outputs/**`) gitignored — don't commit binaries. |
+| `_config/` | user (curated), setup wizard | instance config the skills read. `_config/sources.md` records which streams (`email`/`slack`/`calendar`) the default daily loop-closing flow checks + the git mode. Tracked, low-sensitivity; edit `enabled:` to turn a stream on/off. |
 | `_schemas/` | user, with agent proposals via PR | edits are governance changes |
 | `_templates/` | user, agents (propose-only) | one per type |
 | `_workflows/` | user, agents (propose-only) | step-by-step workflow prompts |
@@ -111,7 +112,7 @@ Given a raw source in `Raw/sources/`:
 
 ### Daily briefing — see [[_workflows/daily-briefing]]
 
-Generate `Ops/Briefings/<today>.md` per the briefing schema, including the People section and the tracker-digest section.
+Generate `Ops/Briefings/<today>.md` per the briefing schema, including the People section and the tracker-digest section. By default the briefing first runs the **loop-closing pass** (Step 1b): `capture-comms` then `reconcile-from-comms` over the streams enabled in `_config/sources.md` (sent + received email/Slack, and calendar if enabled), so state that lagged reality is reconciled before synthesis. Tier-A reversible bookkeeping auto-applies; Tier-B task closes are confirmed in one batch and routed through `close-task` (agents never self-close).
 
 ### Weekly review — see [[_workflows/weekly-review]]
 

--- a/hardened/contract/CLAUDE.base.md
+++ b/hardened/contract/CLAUDE.base.md
@@ -75,7 +75,9 @@ In addition to the paste-able prompts above, the vault ships **Claude Code skill
 | `create-task` | "add a task to ...", "create a task for ...", "block 30 min tomorrow for ...", "put time on for ..." | Writes one schema-conformant Task with a sequential `task-YYYYMMDD-NNN` id, picks the parent Project/Area, optionally creates a matching Google Calendar event when the capture includes a time block, and appends the log line. Invoked by `triage-inbox` and `promote-idea`. |
 | `close-task` | "close [[X]]", "mark this task done", "I finished the X task" | Takes a Task to `status: done` (or `needs_review` / `canceled`) with the required final `# Work log` entry, removes it from the parent Project's `# Current next actions`, surfaces any downstream Tasks the close unblocks, and logs. Agents never set their own work to `done` — that's the user's call. |
 | `capture-decision` | "I've decided to ...", "we're going with X over Y", "record this decision", "decision: ..." | Writes `Decision - <Title>.md` per `_schemas/decision.md` (the six body sections), links it from the parent Project/Area's `# Key decisions`, and handles the supersede chain when a new decision overrides a prior one. Decisions are append-only — never silently rewritten. |
-| `daily-briefing` | "generate the daily briefing", "today's briefing", "morning briefing" | Auto-triggering version of `Agents/Prompts/daily-briefing.md`. Synthesizes the full 13-section briefing into `Ops/Briefings/<date>.md` and refuses to silently overwrite an existing briefing (especially one that already has `## Shutdown notes` appended). |
+| `daily-briefing` | "generate the daily briefing", "today's briefing", "morning briefing" | Auto-triggering version of `Agents/Prompts/daily-briefing.md`. **By default first runs `capture-comms` + `reconcile-from-comms` (Step 1b)** to close loops from your sent/received email + Slack (and calendar if enabled in `_config/sources.md`), then synthesizes the full 13-section briefing into `Ops/Briefings/<date>.md`. The §0 "State confirmation needed" batch is the reconcile Tier-B output. Refuses to silently overwrite an existing briefing (especially one that already has `## Shutdown notes` appended). |
+| `capture-comms` | "capture today's comms", "summarize my email and slack", "what loops did my comms close" | **Phase 1 (capture-only).** Pulls the day's Gmail (sent + received) and Slack (sent + received) — only the streams enabled in `_config/sources.md` — into `Inbox/comms/<date>/` as structured action items. Read-only against Gmail/Slack (never sends/drafts/reacts). Applies nothing; proposes targets for phase 2. |
+| `reconcile-from-comms` | "reconcile my comms", "close the loops from today's comms", "apply the comms digest" | **Phase 2 (loop-closing).** Reads the `Inbox/comms/<date>/` action items, auto-applies reversible Tier-A bookkeeping (bump `last_contact`, mark Followups `acted_on`), and proposes consequential Tier-B changes (close a Task, flip a Letter to submitted, close a passed calendar-linked Task) for explicit batched confirmation. Never auto-closes a Task to `done`; routes confirmed closes through `close-task`. |
 | `shutdown-review` | "shutdown review", "wrap up the day", "end-of-day notes" | Auto-triggering version of `Agents/Prompts/shutdown-review.md`. Walks the five reflection questions, appends `## Shutdown notes — <today>` to today's briefing, and cascades to every touched Task's `# Work log`. Queues learnings as Decisions for capture tomorrow rather than doing them inline. |
 | `run-trackers` | "run the trackers", "Monday tracker pass", "any new digests?" | Auto-triggering version of `Agents/Prompts/run-trackers.md`. Runs each active+due tracker per its `search_strategy`, writes the digest, applies or proposes `update_targets` (per `auto_update_wiki`), and updates tracker bookkeeping. Honors `forbidden_actions:` literally. |
 | `lint` | "run the lint", "audit the vault", "auditor pass" | Auto-triggering version of `Agents/Prompts/lint.md`. Runs the 15-check auditor pass and writes the report into the open weekly review (or a standalone `Lint - <date>.md`). Flag-only — proposes follow-on tasks but creates none. |
@@ -272,6 +274,30 @@ The vault was built against Obsidian Bases 1.7+ but the installed version has th
 - `create-task` may create a Google Calendar event on the user's primary calendar when the new Task carries a `scheduled_start`/`scheduled_end`. No other calendar writes.
 - No other Drive writes — the vault never writes to Drive without explicit per-session opt-in.
 
+## Source streams + git mode (`_config/sources.md`)
+
+Setup (`memex-init`) asks which **streams** the default daily loop-closing flow should
+check and writes the answer to `_config/sources.md` (a tracked, low-sensitivity note):
+
+```yaml
+streams:
+  email:    { enabled: true,  mcp: claude_ai_Gmail }
+  slack:    { enabled: true,  mcp: claude_ai_Slack }
+  calendar: { enabled: true,  mcp: claude_ai_Google_Calendar, mode: minimal }
+```
+
+`capture-comms` scans only enabled email/Slack streams; the `calendar` stream (default
+off) enables the minimal calendar loop-closing in `reconcile-from-comms` (a Task linked to a
+passed calendar event → "confirm close?"). Edit `enabled:` to turn a stream on/off — no
+re-init. If the file is absent, skills default to email + slack enabled, calendar
+planning-only. The connectors themselves are claude.ai MCP connectors you grant in your
+client; capture stays empty (never errors) until a stream is connected.
+
+Setup also offers a **git mode**: `local` (default — git, no remote), `none` (no git, no
+history), or `remote` (git + a remote you push to). With `remote`, note that raw comms under
+`Inbox/` are gitignored and never push, but reconciled facts (closed tasks, Person notes,
+Decisions) do — use a private repo.
+
 ## Out of scope (v0.1)
 
-External integrations not yet wired: email send, Slack capture, mobile voice notes, TaskNotes HTTP API, scheduled tracker daemon. (Google Calendar event creation for Tasks landed via `create-task` — see Authorized external writes above. Wider Drive sync still deferred.) See "Out of scope" in `IMPLEMENTATION_PLAN.md`.
+External integrations not yet wired: email send, mobile voice notes, TaskNotes HTTP API, scheduled tracker daemon. (Email/Slack **capture** landed via `capture-comms` + `reconcile-from-comms`, wired into the daily briefing by default — see the skills table. Google Calendar event creation for Tasks landed via `create-task`. Wider Drive sync still deferred.) See "Out of scope" in `IMPLEMENTATION_PLAN.md`.

--- a/packs/core/schemas/briefing.md
+++ b/packs/core/schemas/briefing.md
@@ -21,6 +21,7 @@ period_start: YYYY-MM-DD
 period_end: YYYY-MM-DD
 includes_calendar: true
 includes_agent_queue: true
+includes_comms: true      # daily briefing ran the default capture-comms + reconcile loop (Step 1b)
 open_tasks_count: 0
 projects_reviewed: 0
 sensitivity: private      # briefings touch everything; default private
@@ -29,6 +30,7 @@ sensitivity: private      # briefings touch everything; default private
 
 ## Body sections (daily)
 
+- (optional) `## 0. State confirmation needed` — rendered above § 1 only when the default comms loop-closing pass ([[reconcile-from-comms]], via daily-briefing Step 1b) or the stale-state queries surface items whose vault status likely lags reality. Absent on a healthy day. Items are numbered for the batched "yes to 1,3" confirmation.
 1. `## 1. Top 3 outcomes for today`
 2. `## 2. Calendar / time map`
 3. `## 3. Tasks due or scheduled today`

--- a/packs/core/schemas/task.md
+++ b/packs/core/schemas/task.md
@@ -28,6 +28,8 @@ context:                  # tags that constrain where/when
 due: YYYY-MM-DD
 scheduled_start:          # ISO datetime if time-blocked
 scheduled_end:
+calendar_event_id:        # Google Calendar event id, set by create-task when it makes the block
+calendar_event_title:     # human-readable event summary (for the briefing's calendar loop-closing)
 follow_up_date:
 blocked_by: []
 unblocks: []
@@ -70,6 +72,7 @@ updated: YYYY-MM-DD
 - A task without a project is permitted only if `area:` is set. The auditor flags tasks with neither.
 - `status: waiting` requires `waiting_on:` to be populated.
 - `status: scheduled` requires `scheduled_start:` and `scheduled_end:`.
+- `calendar_event_id:` is optional; when `create-task` creates a Google Calendar block it records the event id here (and the summary in `calendar_event_title:`) so the daily briefing can later ask "this event's time has passed — close the task?" (calendar loop-closing, gated on the `calendar` stream in `_config/sources.md`).
 - `status: done` requires a final entry in `# Work log` with the outcome.
 - `agent_eligible: true` requires complete `acceptance_criteria` and a populated `# Agent handoff` section.
 - `actual_effort:` is optional but encouraged when known. If set, `actual_effort_source:` should record how the duration was derived (self-report or which observable signal). The `observe-task-actuals` skill populates these on closed Tasks where it can triangulate a signal, and surfaces remaining Tasks for sparse self-report at the weekly review.

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -102,6 +102,13 @@ received. Received comms more often *open* loops (someone asks you for something
 
 ## Steps
 
+0. **Read enabled streams.** Read `_config/sources.md` and look at `streams.*.enabled`.
+   Only scan streams marked `enabled: true`. If the file is absent (older vault),
+   default to **email + slack enabled** (calendar is not a capture stream — it has its
+   own loop-closing path in the briefing; see [[reconcile-from-comms]]). If a stream is
+   disabled, skip its scan entirely and don't write that source's file. This is the
+   per-stream gate the default daily-briefing flow relies on.
+
 1. **Resolve the date + scan window.** Date is today (or the date argument if given). Find the
    most recent prior `Inbox/comms/<date>/` folder to get the last run time; the window is
    (last run → now). If there's no prior run, default to the **last 36 hours** (overlap is safe
@@ -119,7 +126,7 @@ received. Received comms more often *open* loops (someone asks you for something
    proceed with the other source. This is exactly the partial-failure case the two-file split
    exists to handle.
 
-3. **Scan Gmail — both directions.** Use the [[email]] broad-search technique (don't start
+3. **Scan Gmail — both directions** (only if `email` is enabled per Step 0). Use the [[email]] broad-search technique (don't start
    narrow). Cover sent AND received in the window:
    - Received: `in:inbox newer_than:<window>` (and a wider `in:anywhere newer_than:<window>` for
      threads that skip the inbox).
@@ -129,7 +136,7 @@ received. Received comms more often *open* loops (someone asks you for something
    - Mailbox note: `{{OWNER_PRIMARY_EMAIL}}` is primary; `{{OWNER_FORWARDING_EMAIL}}` forwards in.
      A miss is usually a query miss, not an access gap (memory `feedback_gmail_search_technique`).
 
-4. **Scan Slack — both directions, including what I sent.**
+4. **Scan Slack — both directions, including what I sent** (only if `slack` is enabled per Step 0).
    - Resolve the user's own Slack identity first (`slack_read_user_profile` /
      `slack_search_users`) so you can recognize `from:<me>`.
    - Search messages **I sent** in the window (`slack_search_public_and_private` filtered to the
@@ -192,6 +199,7 @@ Phase 1 (this skill) **never** does step 2 or 3. It only produces step 1's input
 
 ## Related
 
+- `_config/sources.md` — the per-stream enable/disable config this skill reads in Step 0.
 - [[cv-scan]] — the propose-only-from-Gmail pattern this mirrors.
 - [[email]] — the broad-search technique + Gmail query cheat-sheet this reuses.
 - [[triage-inbox]] — consumes `Inbox/` items, including the `## Threads worth routing` entries.

--- a/packs/core/skills/create-task/SKILL.md
+++ b/packs/core/skills/create-task/SKILL.md
@@ -85,7 +85,7 @@ If and only if `status: scheduled`, create a Google Calendar event on the user's
 - Description: a one-sentence outcome statement + a link to the Task file path. Example: `Exercise the data pipeline integration end-to-end on a real public dataset before advertising the feature. Linked vault task: Ops/Tasks/Test data pipeline integration in ExampleProject.md`
 - Don't add attendees, don't ask for a Meet link, don't set reminders unless the user said to.
 
-Capture the calendar event ID if the API returns one and stash it in the Task's `# Work log` line so the bidirectional link is recoverable.
+Capture the calendar event ID if the API returns one: write it to the Task's `calendar_event_id:` frontmatter (and the event summary to `calendar_event_title:`) **and** mention it in the `# Work log` line so the bidirectional link is recoverable. The frontmatter field is what lets the daily briefing's calendar loop-closing later ask "this event's time has passed — close the task?" (gated on the `calendar` stream in `_config/sources.md`).
 
 If the user didn't time-block, skip this step entirely — don't ask whether they want a calendar event. A `status: next` Task is a list item; the calendar belongs to time-blocked work.
 

--- a/packs/core/skills/daily-briefing/SKILL.md
+++ b/packs/core/skills/daily-briefing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily-briefing
-description: Generate today's 13-section operating-dashboard briefing for the vault (Top 3 outcomes through End-of-day prompts), open it in the browser, and refuse silent overwrites. Use whenever the user wants today's operating dashboard generated — signaled by phrases like "generate the daily briefing", "today's briefing", "what's the briefing for today", "make today's briefing", "give me the morning briefing", "what's on for today (full version)", or direct invocation "/daily-briefing" / "/daily-briefing 2026-05-19". Synthesizes the vault's current state into `Ops/Briefings/<YYYY-MM-DD>.md` per `_schemas/briefing.md` and the full procedure in `_workflows/daily-briefing.md` — reads active projects, open tasks, waiting-for items, unprocessed inbox, calendar for today + next 7 days, agent jobs, due trackers and fresh digests, surfaced followups, people needing a touch — and produces the 13-section briefing body (Top 3 outcomes, Calendar / time map, Tasks due today, Waiting on others, Projects at risk, New captures needing triage, Agent opportunities, Trackers, People, Followups surfaced today, Decisions needed, Starter prompts, End-of-day review prompts). Refuses to overwrite an existing briefing without explicit confirmation. Use first thing in the morning before starting work, once per day; this skill is the auto-triggering counterpart to the paste prompt at `Agents/Prompts/daily-briefing.md`.
+description: Generate today's 13-section operating-dashboard briefing for the vault (Top 3 outcomes through End-of-day prompts), open it in the browser, and refuse silent overwrites. Use whenever the user wants today's operating dashboard generated — signaled by phrases like "generate the daily briefing", "today's briefing", "what's the briefing for today", "make today's briefing", "give me the morning briefing", "what's on for today (full version)", or direct invocation "/daily-briefing" / "/daily-briefing 2026-05-19". Synthesizes the vault's current state into `Ops/Briefings/<YYYY-MM-DD>.md` per `_schemas/briefing.md` and the full procedure in `_workflows/daily-briefing.md` — reads active projects, open tasks, waiting-for items, unprocessed inbox, calendar for today + next 7 days, agent jobs, due trackers and fresh digests, surfaced followups, people needing a touch — and produces the 13-section briefing body (Top 3 outcomes, Calendar / time map, Tasks due today, Waiting on others, Projects at risk, New captures needing triage, Agent opportunities, Trackers, People, Followups surfaced today, Decisions needed, Starter prompts, End-of-day review prompts). Refuses to overwrite an existing briefing without explicit confirmation. By default it first runs capture-comms + reconcile-from-comms to close loops from your sent/received email and Slack (and calendar if enabled in `_config/sources.md`) before synthesizing, so the briefing reflects work you did off-vault. Use first thing in the morning before starting work, once per day; this skill is the auto-triggering counterpart to the paste prompt at `Agents/Prompts/daily-briefing.md`.
 ---
 
 # Generate today's daily briefing
@@ -38,6 +38,22 @@ Wait for explicit confirmation. The standing rule is one briefing per day; regen
 
 If today's briefing already has a `## Shutdown notes` section appended (from `shutdown-review`), **never** silently overwrite — that's irreplaceable end-of-day content.
 
+(Regenerating is safe with respect to Step 1b: both [[capture-comms]] and [[reconcile-from-comms]] are idempotent — capture regenerates its files in place; reconcile's ledger blocks any double-apply.)
+
+## Step 1b — Close loops from comms (default loop-closing)
+
+This is the default multi-source pass that keeps vault state from lagging reality. It runs **before** synthesis so §0 and the task list reflect what actually happened off-vault (you answered an email, posted in Slack, a meeting ended).
+
+1. **Read `_config/sources.md`.** Determine which streams are `enabled: true`. If the file is absent (older vault), default to **email + slack enabled, calendar planning-only**. If no streams are enabled, skip to Step 2 — the §0 stale-state queries remain as the fallback safety net.
+
+2. **Backfill guard.** If `<date>` is more than ~2 days in the past (a backfilled briefing), **skip the comms refresh** — a comms scan only makes sense near today — and note `(comms refresh skipped — backfilled briefing for a past date)` in §0. Generate from vault state alone.
+
+3. **Run [[capture-comms]]** for `<date>`, enabled streams only. It is read-only against Gmail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`.
+
+4. **Run [[reconcile-from-comms]]** for `<date>` in its **briefing sub-mode** (see that skill's "When invoked by daily-briefing"): it auto-applies Tier-A reversible bookkeeping (bump `last_contact`, mark Followups `acted_on`) and **returns the Tier-B proposals** — task closes, Letter→submitted, and (if the `calendar` stream is enabled) passed-event closes — **without prompting**. Hold those proposals for §0 and the batched report-back (Step 6).
+
+Tasks that Tier-A already advanced will read correctly through the rest of the briefing. Tier-B proposals are **not** applied here — the user confirms them in one batch in Step 6, preserving the "agents never self-close" guardrail.
+
 ## Step 2 — Gather inputs (in parallel)
 
 Run these reads in parallel — one message, multiple tool calls. Read only what exists; skip gracefully if a folder is absent.
@@ -55,9 +71,14 @@ Run these reads in parallel — one message, multiple tool calls. Read only what
 
 Also pull yesterday's briefing's "## Shutdown notes" section if present — it carries the user's last signal about energy, surprises, and unresolved questions, which directly informs today's Top 3 outcomes.
 
-## Step 2b — Stale-state pre-flight (catch silent close-loop gaps)
+## Step 2b — Build § 0 "State confirmation needed"
 
-Before § 1, scan for vault items where state likely lags reality. The user does work off-vault (sends emails, uploads to portals, runs lints) without invoking the close-out skill, so notes silently rot at the previous status. The briefing is the natural daily checkpoint to surface these.
+§ 0 is populated from **two sources, merged and deduped**:
+
+- **(a) Reconcile Tier-B proposals** returned by [[reconcile-from-comms]] in Step 1b — real signal from your actual sent/received comms and (if enabled) calendar. These are the high-confidence items.
+- **(b) The four vault pre-flight queries below** — the safety net for state changes that *no* comm covered (e.g. a scheduled block that simply passed with no email/Slack about it).
+
+When (a) and (b) point at the same note, keep the reconcile proposal (it carries the signal) and drop the duplicate. If Step 1b was skipped (no streams enabled, or the backfill guard fired), § 0 is just (b).
 
 Four pre-flight queries (run in parallel):
 
@@ -66,20 +87,21 @@ Four pre-flight queries (run in parallel):
 3. **Tasks `in_progress` with stale work log** — `Ops/Tasks/*.md` where `status: in_progress` AND last `# Work log` entry older than 5 days. Either drift (should close) or genuine in-flight work (legitimate).
 4. **Scheduled tasks whose block has passed** — `Ops/Tasks/*.md` where `status: scheduled` AND `scheduled_end < now`. The single most common lag case: a time-blocked task came and went without being closed *or* rescheduled. Surfacing these is how the next morning's briefing catches "I had a full day and four blocks slipped." Multiple scheduled blocks can silently carry because the original three queries didn't cover scheduled-but-not-closed; this query is the fix.
 
-For each hit, render a line in a new **`## 0. State confirmation needed`** section at the very top of the briefing (above § 1) — exactly this format:
+For each item (from either source), render a line in a new **`## 0. State confirmation needed`** section at the very top of the briefing (above § 1) — exactly this format:
 
 ```markdown
 ## 0. State confirmation needed
 
 The vault thinks the following are still in progress. Were any of them already done?
 
-- [[<Letter or Task wikilink>]] — `status: <current>` (due <date>). If submitted/done: edit the note's `status:` + `submitted:`/Work log, then this lifts.
-- ...
+1. [[<Task or Letter wikilink>]] — `status: <current>` (due <date>).
+   ↳ signal: <e.g. "you emailed Alex the draft 2026-06-03" — present for reconcile-sourced items; omit for pure stale-state hits>
+2. ...
 
-Reply yes/no/partial in chat and the planner will close the loop.
+Reply with the numbers that are done (e.g. "yes to 1,3") and the planner will close them via [[close-task]].
 ```
 
-If no items hit any of the four queries, omit this section entirely. The signal of a healthy vault is that § 0 is absent.
+Number the items so the Step 6 batched confirm ("yes to 1,3,4") maps cleanly. If § 0 is empty (no reconcile proposals and no query hits), omit the section entirely — its absence is the signal of a healthy vault.
 
 **In the chat report-back (Step 6),** also surface this list above the Top 3 — see Step 6.
 
@@ -101,6 +123,7 @@ period_start: <date>
 period_end: <date>
 includes_calendar: true
 includes_agent_queue: true
+includes_comms: <true if Step 1b ran; false if skipped>
 open_tasks_count: <count>
 projects_reviewed: <count>
 sensitivity: private
@@ -188,11 +211,11 @@ Skip this step only if the user explicitly says "don't open it" or "just write t
 ```
 Briefing generated: Ops/Briefings/<date>.md (opened in browser at http://localhost:{{QUARTZ_PORT}}/Ops/Briefings/<date>).
 
-<IF Step 2b produced any items:>
-**State confirmation needed first** (vault may be lagging reality):
-- [[<item 1>]] — still <status>. Was this actually done?
-- [[<item 2>]] — ...
-Reply yes/no/partial and I'll close the loop.
+<IF § 0 has items:>
+**Confirm these closes** (vault may be lagging reality — from your comms/calendar + a vault scan):
+1. [[<item 1>]] — still <status>. <signal, if reconcile-sourced>
+2. [[<item 2>]] — ...
+Reply with the ones that are done (e.g. "yes to 1,3") and I'll close them.
 
 Top 3 outcomes:
 1. <outcome 1>
@@ -202,7 +225,13 @@ Top 3 outcomes:
 Notable: <one bullet for the most consequential at-risk project or surfaced followup, or "nothing surprising">.
 ```
 
-Surface the § 0 items at the top of the chat report-back if present — the user reads the chat before opening the briefing file, and closing stale state in the same session is the whole point of the pre-flight. If they reply "yes, all done" for any item, immediately edit the source note (`status:`/`submitted:`/Work log) and append a log entry. The user shouldn't have to re-invoke a separate closure skill for trivially obvious closures.
+Surface the § 0 items at the top of the chat report-back if present — the user reads the chat before opening the briefing file, and closing stale state in the same session is the whole point. This is the **single batched confirmation** for everything Step 1b proposed. When the user confirms ("yes to 1,3"):
+
+- **Task closes → route through [[close-task]]** (never hand-edit `status: done` — close-task enforces the final `# Work log` entry and the `unblocks:` cascade, and the "agents never self-close" guardrail means this confirmation is what authorizes it).
+- **Letter `drafting → submitted`** → the clean two-field edit (`status:` + `submitted:`), per [[reconcile-from-comms]].
+- Then **update [[reconcile-from-comms]]'s ledger + checkboxes** for each item so a later standalone reconcile run doesn't re-propose them, and append the `log.md` line(s).
+
+(Tier-A reversible bookkeeping was already applied in Step 1b — don't re-apply it here.)
 
 Don't recapitulate the whole briefing in chat — the file is the artifact.
 
@@ -222,6 +251,8 @@ Don't recapitulate the whole briefing in chat — the file is the artifact.
 - `Agents/Prompts/daily-briefing.md` — paste-able prompt equivalent.
 - `_workflows/daily-briefing.md` — the canonical procedure.
 - `_schemas/briefing.md` — the schema.
+- `capture-comms` / `reconcile-from-comms` — Step 1b runs these by default to close loops from your email/Slack (and calendar if enabled) before synthesis.
+- `_config/sources.md` — which streams Step 1b checks; edit it to turn a stream on/off.
 - `shutdown-review` — the end-of-day counterpart that appends to this briefing.
 - `session-start` — the lighter-weight pre-flight (5–10 seconds vs. several minutes here).
 - `log-mutation` — the canonical log-append helper.

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -18,9 +18,11 @@ pre-flight — it relied on the user remembering; this reads the captured signal
 
 ## Hard rules (non-negotiable)
 
-- **The `## Action items` sections are the only input.** Parse the phase-1 checkbox + `↳` blocks
+- **The `## Action items` sections are the primary input.** Parse the phase-1 checkbox + `↳` blocks
   from `Inbox/comms/<date>/*.md`. The prose sections (`## Summary`, `## Threads worth routing`,
-  `## Filtered as noise`) are context, not instructions.
+  `## Filtered as noise`) are context, not instructions. (One addition: the optional
+  **calendar loop-closing** pass below contributes Tier-B proposals from vault Tasks whose linked
+  calendar event has passed, when the `calendar` stream is enabled in `_config/sources.md`.)
 - **Two tiers, and the line between them is firm** (see table). Auto-apply ONLY reversible CRM
   bookkeeping. Everything consequential, irreversible, sensitive, or needing a narrative is
   **proposed and held for explicit confirmation** — apply nothing in that tier until the user says
@@ -48,6 +50,7 @@ pre-flight — it relied on the user remembering; this reads the captured signal
 | **B — confirm first** | Letter `drafting → submitted` (+ set `submitted:` date) | Confirm → `Edit` the Letter note | Asserts an external state; consequential |
 | **B — confirm first** | Capture a Decision the comms imply | Confirm → [[capture-decision]] | Needs rationale/alternatives; often sensitive |
 | **B — confirm first** | Create a new Task / Followup / Person / Source from a routing suggestion | Confirm → [[create-task]] / [[ingest-person]] / [[ingest-source]] | New entities are commitments |
+| **B — confirm first** | Close a Task whose linked calendar event has passed | Confirm → [[close-task]] | External state; agents never self-close (calendar pass below) |
 | **B — always** | Anything `[sensitive]` or any p0/p1 Task | Confirm only — never auto | Sensitivity + stakes |
 
 When a Tier-A change is uncertain (confidence `low`, or no clean note match), demote it to Tier B
@@ -113,6 +116,42 @@ job, and the mark is the idempotency key. For each reconciled item:
    skill, and what was skipped (with the sensitive/uncertain reason). Offer the obvious follow-ons
    (e.g. "want me to run [[capture-decision]] on the leadership meeting now?") but don't act unprompted.
 
+## Calendar loop-closing (gated on the `calendar` stream)
+
+A minimal, opt-in pass that runs **only** when `_config/sources.md` has
+`streams.calendar.enabled: true` (default off). It catches the common lag where a
+meeting happened but its prep/follow-up Task is still open.
+
+1. Find open Tasks (`status` not in `[done, canceled]`) carrying a `calendar_event_id:`.
+2. Determine whether the linked event's end-time has passed. Prefer a live lookup via
+   the Calendar MCP (`mcp__claude_ai_Google_Calendar__get_event`) so you also see if
+   the event was **canceled/declined**; if the MCP is unavailable, fall back to the
+   Task's `scheduled_end` / `calendar_event_title` and the current time.
+3. For an event that **occurred** and is past: propose a **Tier-B** close —
+   `Close [[<Task>]] — its calendar event "<title>" ended <when>. Done?` Confirm → [[close-task]].
+4. For an event that was **canceled/declined**: propose **Tier-B** instead as
+   "reschedule or drop?" — never auto-close (the work may still be owed). Surface it; let
+   the user decide.
+
+No attendee matching and no `last_contact` bumping — that's deliberately out of scope
+(the "minimal" choice). These proposals merge into the same Tier-B batch as the comms
+items and obey the same confirm-then-`close-task` rule.
+
+## When invoked by daily-briefing
+
+`daily-briefing` runs this skill as Step 0c of generating the morning briefing. In that
+context:
+
+- **Apply Tier-A exactly as normal** (reversible bookkeeping — bump `last_contact`, mark
+  a Followup `acted_on`) and update the ledger.
+- **Do NOT run the interactive Step 6 prompt.** Instead, hand the Tier-B proposals (comms
+  closes + the calendar pass above) back to the briefing. The briefing renders them in its
+  **§0 "State confirmation needed"** and owns the single batched confirmation in its
+  report-back. When the user later confirms ("yes to 1,3,4"), route each through
+  [[close-task]] / the owning skill and update this skill's ledger + checkboxes then.
+
+Run standalone (direct `/reconcile-from-comms`), Step 6 stays interactive as written.
+
 ## What this skill never does
 
 - Send / draft / react-to / schedule any email or Slack message.
@@ -130,5 +169,6 @@ job, and the mark is the idempotency key. For each reconciled item:
 
 - [[capture-comms]] — phase 1; produces the `Inbox/comms/<date>/` files this consumes.
 - [[close-task]] / [[create-task]] / [[capture-decision]] / [[ingest-person]] / [[ingest-source]] — the owning skills it delegates consequential changes to.
-- [[daily-briefing]] — its §0 "State confirmation needed" pre-flight; this skill is the signal-driven upgrade.
+- [[daily-briefing]] — runs this skill as Step 1b by default; its §0 "State confirmation needed" is this skill's Tier-B output (see "When invoked by daily-briefing" above).
+- `_config/sources.md` — gates the calendar loop-closing pass (`streams.calendar.enabled`).
 - `Daily comms digest and automated loop-closing` (idea) — the full two-phase design + the "major item" threshold rationale.

--- a/packs/core/workflows/daily-briefing.md
+++ b/packs/core/workflows/daily-briefing.md
@@ -4,6 +4,16 @@
 **Trigger:** `Ops/Briefings/<today>.md` does not exist; or explicit user request
 **Output:** `Ops/Briefings/<today>.md`
 
+## Default loop-closing pass (Step 1b)
+
+Before gathering the inputs below, run the default multi-source loop-closing pass (the
+skill version automates this; pasting the prompt, do it by hand): read `_config/sources.md`
+for enabled streams, run `capture-comms` (sent + received email/Slack) then
+`reconcile-from-comms` for today. Tier-A reversible bookkeeping auto-applies; Tier-B task
+closes (plus passed calendar-event closes if the `calendar` stream is enabled) become the
+numbered `## 0. State confirmation needed` section, confirmed in one batch. Skip this pass
+for backfilled briefings more than ~2 days old.
+
 ## Inputs to read
 
 - `log.md` since the last briefing

--- a/tests/fixtures/answers.nogit.json
+++ b/tests/fixtures/answers.nogit.json
@@ -1,0 +1,20 @@
+{
+  "OWNER_NAME": "Jane Roe",
+  "OWNER_PRIMARY_EMAIL": "jane@example.com",
+  "OWNER_FORWARDING_EMAIL": "",
+  "FRAMING": "CSO at Example Bio",
+  "VAULT_PATH": "/tmp/example-vault",
+  "USER_HOME": "/Users/jane",
+  "DRIVE_MOUNT": "",
+  "LETTERS_DRIVE_ID": "",
+  "LETTERHEAD_TEMPLATE_ID": "",
+  "QUARTZ_PORT": "8181",
+  "QUARTZ_WS_PORT": "3101",
+  "CC_PROJECT_SLUG": "-tmp-example-vault",
+  "GITHUB_ORG": "exampleorg",
+  "LAB_WEBSITE_PATH": "",
+  "TIMEZONE": "America/Los_Angeles",
+  "VAULT_NAME": "example-vault",
+  "STREAMS": "email,slack,calendar",
+  "GIT_MODE": "none"
+}

--- a/tests/test_init.sh
+++ b/tests/test_init.sh
@@ -26,6 +26,13 @@ no_unbaked() {  # $1 = dir
 [ -f "$TMP/core/CLAUDE.md" ] || fail "CLAUDE.md missing"
 [ -f "$TMP/core/scripts/serve_quartz.sh" ] || fail "serve_quartz.sh not at scripts/"
 [ -f "$TMP/core/scripts/launchd/com.memex.quartz.plist" ] || fail "launchd plist missing/misnamed"
+# sources config seed: present, default streams (email+slack on, calendar off), local git
+[ -f "$TMP/core/_config/sources.md" ] || fail "_config/sources.md seed missing"
+grep -q "email: { enabled: true" "$TMP/core/_config/sources.md" || fail "email stream not enabled by default"
+grep -q "slack: { enabled: true" "$TMP/core/_config/sources.md" || fail "slack stream not enabled by default"
+grep -q "calendar: { enabled: false" "$TMP/core/_config/sources.md" || fail "calendar should default off"
+grep -q "git_mode: local" "$TMP/core/_config/sources.md" || fail "default git_mode should be local"
+[ -d "$TMP/core/.git" ] || fail "local git mode should init a repo"
 grep -q "memex-quartz" "$TMP/core/.claude/settings.json" 2>/dev/null && fail "settings.json should reference hooks not launchd" || true
 no_unbaked "$TMP/core"
 grep -rq "jane@example.com" "$TMP/core/.claude/skills" || fail "owner email not baked into skills"
@@ -42,7 +49,14 @@ no_unbaked "$TMP/pi"
 # pi port baked distinctly
 grep -q "8182" "$TMP/pi/quartz/package.json" || fail "pi QUARTZ_PORT not baked"
 
+# ---------- git mode none + calendar stream ----------
+"$ENG/bin/memex-init" --target "$TMP/nogit" --packs core --answers "$ENG/tests/fixtures/answers.nogit.json" >/dev/null
+[ -f "$TMP/nogit/_config/sources.md" ] || fail "_config/sources.md missing (nogit)"
+grep -q "calendar: { enabled: true" "$TMP/nogit/_config/sources.md" || fail "calendar stream not enabled when requested"
+grep -q "git_mode: none" "$TMP/nogit/_config/sources.md" || fail "git_mode none not recorded"
+[ ! -d "$TMP/nogit/.git" ] || fail "git mode none should NOT init a repo"
+
 # ---------- guards ----------
 "$ENG/bin/memex-init" --target "$TMP/core" --packs core --answers "$ENG/tests/fixtures/answers.core.json" 2>/dev/null && fail "should refuse non-empty target" || true
 
-echo "PASS: memex-init core + pi + guards"
+echo "PASS: memex-init core + pi + sources/git + guards"

--- a/tools/memex_init.py
+++ b/tools/memex_init.py
@@ -27,17 +27,20 @@ STREAM_MCP = {
 VALID_GIT_MODES = ["local", "none", "remote"]
 
 def parse_streams(raw):
-    """Normalize a STREAMS answer (list, comma-string, or None/"") into an ordered,
-    de-duplicated list of valid stream names. Unknown names are dropped; an empty
-    result falls back to the default (email + slack)."""
-    if raw is None or raw == "":
+    """Normalize a STREAMS answer into an ordered, de-duplicated list of valid
+    stream names. `None` means 'not answered' (the key was absent) and falls back
+    to the default (email + slack). Any other value is taken literally — an
+    explicit empty selection stays empty, so the user can opt out of all comms
+    scanning; unknown names are dropped. (The daily briefing supports a
+    zero-stream config: it just skips the comms pass.)"""
+    if raw is None:
         return list(DEFAULT_STREAMS)
     items = raw.split(",") if isinstance(raw, str) else list(raw)
     seen, out = set(), []
     for s in (str(x).strip().lower() for x in items):
         if s in VALID_STREAMS and s not in seen:
             seen.add(s); out.append(s)
-    return out or list(DEFAULT_STREAMS)
+    return out
 
 def normalize_git_mode(raw):
     """Coerce a GIT_MODE answer to one of local|none|remote (default local)."""
@@ -147,7 +150,7 @@ def ask_streams():
         on = (v in ("y", "yes")) if v else on_by_default
         if on:
             chosen.append(s)
-    return chosen or list(DEFAULT_STREAMS)
+    return chosen  # may be empty — an explicit opt-out of all comms scanning
 
 def ask_git_mode():
     """Privacy-aware version-control mode. local (default) | none | remote."""

--- a/tools/memex_init.py
+++ b/tools/memex_init.py
@@ -9,9 +9,78 @@ Bakes {{TOKENS}} -> answers, copies selected packs + hardened core, scaffolds
 folders, installs + wires hooks, assembles the contract. Refuses to write into a
 non-empty target unless --force (which overlays, it does not wipe).
 """
-import argparse, json, pathlib, re, shutil, subprocess, sys
+import argparse, datetime, json, pathlib, re, shutil, subprocess, sys
 
 TOKEN_RE = re.compile(r"\{\{([A-Z0-9_]+)\}\}")
+
+# --- Source streams + git mode (behavior answers, NOT {{TOKEN}} placeholders) ---
+# These configure the default multi-source loop-closing flow and are read directly
+# from the answers dict (key STREAMS / GIT_MODE), so they never enter
+# placeholders.json (which stays the audited token catalog).
+VALID_STREAMS = ["email", "slack", "calendar"]
+DEFAULT_STREAMS = ["email", "slack"]
+STREAM_MCP = {
+    "email": "claude_ai_Gmail",
+    "slack": "claude_ai_Slack",
+    "calendar": "claude_ai_Google_Calendar",
+}
+VALID_GIT_MODES = ["local", "none", "remote"]
+
+def parse_streams(raw):
+    """Normalize a STREAMS answer (list, comma-string, or None/"") into an ordered,
+    de-duplicated list of valid stream names. Unknown names are dropped; an empty
+    result falls back to the default (email + slack)."""
+    if raw is None or raw == "":
+        return list(DEFAULT_STREAMS)
+    items = raw.split(",") if isinstance(raw, str) else list(raw)
+    seen, out = set(), []
+    for s in (str(x).strip().lower() for x in items):
+        if s in VALID_STREAMS and s not in seen:
+            seen.add(s); out.append(s)
+    return out or list(DEFAULT_STREAMS)
+
+def normalize_git_mode(raw):
+    """Coerce a GIT_MODE answer to one of local|none|remote (default local)."""
+    m = (raw or "local").strip().lower()
+    return m if m in VALID_GIT_MODES else "local"
+
+def sources_config_yaml(streams, git_mode, today):
+    """Render the _config/sources.md note for the given enabled streams. Every
+    valid stream gets a line (enabled true/false) so the file documents the full
+    set; calendar carries mode: minimal."""
+    def line(name):
+        en = "true" if name in streams else "false"
+        extra = ", mode: minimal" if name == "calendar" else ""
+        return f"  {name}: {{ enabled: {en}, mcp: {STREAM_MCP[name]}{extra} }}"
+    rows = "\n".join(line(s) for s in VALID_STREAMS)
+    return f"""---
+type: config
+scope: sources
+git_mode: {git_mode}
+updated: {today}
+streams:
+{rows}
+---
+
+# Sources
+
+Which streams the daily loop-closing flow checks. `capture-comms` +
+`reconcile-from-comms` run by default at the top of `daily-briefing`; flip an
+`enabled:` above to turn a stream on or off — no re-init needed.
+
+- **email** / **slack** — scanned by `capture-comms` (sent + received). Sent
+  messages are the strongest loop-*closing* signals.
+- **calendar** (`mode: minimal`) — a Task linked to a calendar event whose end-time
+  has passed becomes a "confirm close?" item; no attendee / `last_contact` bumping.
+
+If this file is absent, skills fall back to: email + slack enabled, calendar
+planning-only.
+
+## Adding a new source (e.g. Notion)
+1. Add a `streams.<name>` entry above with its MCP server id.
+2. Add a scan block for that MCP to `capture-comms` (Step 3/4).
+3. No `reconcile-from-comms` change needed — it reads the same `## Action items` API.
+"""
 
 def bake(text, answers):
     """Replace {{TOKEN}} with answers[TOKEN]. Unknown tokens are left INTACT —
@@ -41,7 +110,7 @@ SCAFFOLD_DIRS = [
     "Atlas/Trackers/Digests","Atlas/Efforts","Atlas/Relationships","Atlas/Interactions",
     "Ops/Tasks","Ops/Briefings","Ops/Reviews","Ops/Followups","Ops/Views",
     "Agents/Jobs","Agents/Runs","Agents/Approvals",
-    "Raw/sources","Inbox","outputs","Drafts",
+    "Raw/sources","Inbox","outputs","Drafts","_config",
 ]
 
 PORT_TOKENS = {"QUARTZ_PORT", "QUARTZ_WS_PORT"}
@@ -64,7 +133,49 @@ def interview(manifest, packs):
             continue
         v = input(f"{ph['prompt']} [{ph.get('example','')}]: ").strip()
         ans[ph["token"]] = v or (ph.get("example","") if ph["token"] in PORT_TOKENS else v)
+    ans["STREAMS"] = ask_streams()
+    ans["GIT_MODE"] = ask_git_mode()
     return ans
+
+def ask_streams():
+    """Per-stream y/n for the default loop-closing flow. Email + slack default on."""
+    print("\nWhich streams should the daily flow check by default (capture-comms)?")
+    chosen = []
+    for s in VALID_STREAMS:
+        on_by_default = s in DEFAULT_STREAMS
+        v = input(f"  Enable {s}? [{'Y/n' if on_by_default else 'y/N'}]: ").strip().lower()
+        on = (v in ("y", "yes")) if v else on_by_default
+        if on:
+            chosen.append(s)
+    return chosen or list(DEFAULT_STREAMS)
+
+def ask_git_mode():
+    """Privacy-aware version-control mode. local (default) | none | remote."""
+    print("\nVersion-control mode for this vault:")
+    print("  local  — git, local-only, no remote (recommended; default)")
+    print("  none   — no git (no history, no audit trail, no recovery)")
+    print("  remote — git + a remote (PRIVACY: reconciled facts leave your machine)")
+    return normalize_git_mode(input("  git mode [local]: ").strip().lower())
+
+def print_post_init(streams, git_mode):
+    """Print stream-access grant instructions + git-mode guidance/warnings."""
+    if streams:
+        print("\nEnabled streams: " + ", ".join(streams))
+        print("To let Claude read each, connect its MCP connector in your client")
+        print("(Claude.ai → Settings → Connectors, or your MCP config):")
+        for s in streams:
+            print(f"  - {s}: {STREAM_MCP[s]}")
+        print("Capture stays empty (never errors) until a stream is connected.")
+    if git_mode == "none":
+        print("\ngit mode: none — no version history. You lose the audit trail,")
+        print("time-travel, and recovery from a bad edit. Run `git init` later to enable.")
+    elif git_mode == "remote":
+        print("\ngit mode: remote — set up your remote (use a PRIVATE repo):")
+        print("  git -C <vault> remote add origin <url>")
+        print("  git -C <vault> push -u origin main")
+        print("PRIVACY: raw comms under Inbox/ are gitignored and never push, but")
+        print("reconciled facts (closed tasks, Person notes, Decisions) DO push;")
+        print("`sensitivity: sensitive` notes would sync. Keep the remote private.")
 
 def main():
     ap = argparse.ArgumentParser()
@@ -86,6 +197,8 @@ def main():
     T.mkdir(parents=True, exist_ok=True)
 
     answers = interview(manifest, packs) if a.interview else json.load(open(a.answers))
+    streams = parse_streams(answers.get("STREAMS"))
+    git_mode = normalize_git_mode(answers.get("GIT_MODE"))
     answers = answers_with_defaults(manifest, answers)
 
     # 1. folders
@@ -151,15 +264,21 @@ def main():
         f"# {owner + ' — ' if owner else ''}Memex\n\n"
         "Home page for this vault. Browse the typed-note dashboards at "
         "`/dashboards/`, or read `AGENTS.md` for how agents operate here.\n")
+    # sources config: which streams the default loop-closing flow checks
+    (T/"_config/sources.md").write_text(
+        sources_config_yaml(streams, git_mode, datetime.date.today().isoformat()))
 
-    # 6. git init (a vault is a git repo; remote is the user's choice — local-only by default)
-    try:
-        if not (T/".git").exists():
-            subprocess.run(["git", "init", "-q"], cwd=str(T), check=False)
-    except FileNotFoundError:
-        pass  # git not installed — the user can init later
+    # 6. git init — conditional on the chosen mode. local (default) and remote both
+    #    init a repo (remote adds a remote later, by hand); none skips git entirely.
+    if git_mode != "none":
+        try:
+            if not (T/".git").exists():
+                subprocess.run(["git", "init", "-q"], cwd=str(T), check=False)
+        except FileNotFoundError:
+            pass  # git not installed — the user can init later
 
     print(f"init: created instance at {T} (packs: {','.join(packs)})")
+    print_post_init(streams, git_mode)
     return 0
 
 if __name__ == "__main__":

--- a/tools/test_memex_init.py
+++ b/tools/test_memex_init.py
@@ -1,5 +1,7 @@
 import unittest
-from memex_init import bake
+from memex_init import (
+    bake, parse_streams, normalize_git_mode, sources_config_yaml, DEFAULT_STREAMS,
+)
 
 class TestBake(unittest.TestCase):
     def test_replaces_known_tokens(self):
@@ -17,6 +19,49 @@ class TestBake(unittest.TestCase):
     def test_value_with_braces_not_re_expanded(self):
         # an answer value containing a token is NOT re-processed (single pass)
         self.assertEqual(bake("{{A}}", {"A": "{{B}}", "B": "z"}), "{{B}}")
+
+class TestParseStreams(unittest.TestCase):
+    def test_none_and_empty_fall_back_to_default(self):
+        self.assertEqual(parse_streams(None), DEFAULT_STREAMS)
+        self.assertEqual(parse_streams(""), DEFAULT_STREAMS)
+
+    def test_comma_string(self):
+        self.assertEqual(parse_streams("email,calendar"), ["email", "calendar"])
+
+    def test_list_with_whitespace_and_case(self):
+        self.assertEqual(parse_streams([" Email ", "SLACK"]), ["email", "slack"])
+
+    def test_drops_unknown_and_dedupes_preserving_order(self):
+        self.assertEqual(parse_streams("calendar,bogus,email,email"),
+                         ["calendar", "email"])
+
+    def test_all_unknown_falls_back_to_default(self):
+        self.assertEqual(parse_streams("notion,linear"), DEFAULT_STREAMS)
+
+class TestGitMode(unittest.TestCase):
+    def test_defaults_and_valid(self):
+        self.assertEqual(normalize_git_mode(None), "local")
+        self.assertEqual(normalize_git_mode(""), "local")
+        self.assertEqual(normalize_git_mode("REMOTE"), "remote")
+        self.assertEqual(normalize_git_mode(" none "), "none")
+
+    def test_invalid_falls_back_to_local(self):
+        self.assertEqual(normalize_git_mode("svn"), "local")
+
+class TestSourcesConfigYaml(unittest.TestCase):
+    def test_enabled_flags_reflect_streams(self):
+        out = sources_config_yaml(["email", "slack"], "local", "2026-06-04")
+        self.assertIn("email: { enabled: true, mcp: claude_ai_Gmail }", out)
+        self.assertIn("slack: { enabled: true, mcp: claude_ai_Slack }", out)
+        self.assertIn("calendar: { enabled: false,", out)
+        self.assertIn("git_mode: local", out)
+        self.assertIn("updated: 2026-06-04", out)
+
+    def test_calendar_carries_minimal_mode_when_enabled(self):
+        out = sources_config_yaml(["calendar"], "remote", "2026-06-04")
+        self.assertIn("mode: minimal", out)
+        self.assertIn("calendar: { enabled: true,", out)
+        self.assertIn("git_mode: remote", out)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_memex_init.py
+++ b/tools/test_memex_init.py
@@ -21,9 +21,14 @@ class TestBake(unittest.TestCase):
         self.assertEqual(bake("{{A}}", {"A": "{{B}}", "B": "z"}), "{{B}}")
 
 class TestParseStreams(unittest.TestCase):
-    def test_none_and_empty_fall_back_to_default(self):
+    def test_none_means_not_answered_falls_back_to_default(self):
+        # key absent in answers.json -> use the default
         self.assertEqual(parse_streams(None), DEFAULT_STREAMS)
-        self.assertEqual(parse_streams(""), DEFAULT_STREAMS)
+
+    def test_explicit_empty_stays_empty(self):
+        # answered-but-empty (interview opt-out, or "STREAMS": "") -> no streams
+        self.assertEqual(parse_streams(""), [])
+        self.assertEqual(parse_streams([]), [])
 
     def test_comma_string(self):
         self.assertEqual(parse_streams("email,calendar"), ["email", "calendar"])
@@ -35,8 +40,9 @@ class TestParseStreams(unittest.TestCase):
         self.assertEqual(parse_streams("calendar,bogus,email,email"),
                          ["calendar", "email"])
 
-    def test_all_unknown_falls_back_to_default(self):
-        self.assertEqual(parse_streams("notion,linear"), DEFAULT_STREAMS)
+    def test_present_but_all_unknown_yields_empty(self):
+        # a provided value is taken literally; unknown names drop to empty
+        self.assertEqual(parse_streams("notion,linear"), [])
 
 class TestGitMode(unittest.TestCase):
     def test_defaults_and_valid(self):


### PR DESCRIPTION
## What

Makes the daily briefing **close loops from your communications by default**, and adds a setup wizard that asks which streams you use and how you want version control / privacy handled.

Most of the runtime already existed (`capture-comms` scans Gmail + Slack sent **and** received; `reconcile-from-comms` closes the loops) but was manual and not wired into the briefing. This PR wires it in, adds a minimal calendar path, and adds the setup-time configuration.

Design spec: `docs/superpowers/specs/2026-06-04-default-multi-source-loop-closing-design.md`.

## Decisions (agreed before implementing)

- **Guardrail kept, with batching.** Reconcile auto-applies only reversible bookkeeping (bump `last_contact`, mark a Followup `acted_on`); task closes stay propose-only and are confirmed in one batch. The "agents never self-close to `done`" hard-no is preserved.
- **Trigger = inside `daily-briefing`** (Step 1b), run in your authenticated session — avoids the headless-auth gap a cron job would hit. No new background infra.
- **Calendar = minimal.** Only an open Task linked to a *passed* calendar event becomes a "confirm close?" item. No attendee matching, no `last_contact` bumping.
- **Extensibility = three + config list + doc path.** Streams live in an editable config note, not hard-coded.

## Changes

**Runtime**
- `daily-briefing` Step 1b: read `_config/sources.md` → run `capture-comms` (enabled streams only) → run `reconcile-from-comms` in a briefing sub-mode (auto-apply Tier-A, return Tier-B). §0 "State confirmation needed" is now the reconcile Tier-B batch merged + deduped with the existing stale-state queries; confirmed closes route through `close-task`. Backfill guard skips the comms scan for briefings >2 days old.
- `reconcile-from-comms`: documents the briefing sub-mode (defer Tier-B to caller) and adds the minimal calendar pass (gated on `streams.calendar.enabled`).
- `capture-comms`: reads `_config/sources.md` and scans only enabled streams.
- `create-task` + `task.md`: persist a `calendar_event_id` / `calendar_event_title` so the calendar pass can find passed events.

**Setup**
- `memex_init.py` interview: per-stream y/n selection + a git mode (`local` default · `none` · `remote` with a privacy warning). Writes `_config/sources.md`; git init is now conditional. Prints MCP-connector grant instructions at the end. `STREAMS`/`GIT_MODE` are behavior answers (not `{{TOKEN}}` placeholders), so `placeholders.json` stays the audited catalog.

**Docs**
- Contract (`CLAUDE.base.md` / `AGENTS.base.md`): skills-table rows for `capture-comms` + `reconcile-from-comms`, the new default flow, `_config/sources.md`, git modes, and corrected the stale "Out of scope: Slack capture" line.

## Privacy

`Inbox/*` (including all raw comms digests) stays gitignored and never enters git. The `remote` git mode prints a warning that *reconciled facts* (closed tasks, Person notes, Decisions) do push — recommends a private repo. Per-note gitignore-by-frontmatter is noted as future work.

## Testing

- `python3 -m unittest` in `tools/` — 13 pass (incl. new `parse_streams` / `normalize_git_mode` / `sources_config_yaml` tests).
- `tests/test_init.sh` — PASS (asserts the `_config/sources.md` seed, default streams, and conditional git for local/none).
- `audit_literals.py ./packs` and `./hardened` — both AUDIT CLEAN.
- Manual smoke tests of all three git modes (local/none/remote).

## Derive note

These edits are made directly in the engine repo (the working copy). The engine is normally *derived* from a source vault via `tools/derive.py`; a future derive run would need the same changes applied in that source vault too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)