### PR TITLE
Fix log-mutation.sh parse error on macOS system bash 3.2 (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ python3 tools/audit_literals.py ./hardened                # must be AUDIT CLEAN
 python3 tools/audit_refs.py .                          # must be REFS CLEAN
 (cd tools && python3 -m unittest)                         # bake() unit tests
 tests/test_init.sh                                        # full init integration test (core + pi)
+tests/test_hooks.sh                                       # hook behavior + bash 3.2 parse guard (#13)
 ```
+
+Run `tests/test_hooks.sh` on macOS (system bash 3.2): it exercises `log-mutation.sh` under
+`/bin/bash` and statically forbids the heredoc-in-`$()` form that bash 3.2 can't parse. Since the
+hooks are derived from the source vault, re-deriving from a source whose hook still has that pattern
+would reintroduce the bug — this gate catches that.
 
 `derive.py` never modifies the source vault, and its selective wipe never touches the hand-curated
 `hardened/contract/` (AGENTS.base.md, CLAUDE.base.md, pi-fragment.md).

--- a/hardened/hooks/log-mutation.sh
+++ b/hardened/hooks/log-mutation.sh
@@ -16,9 +16,13 @@ hook_input="$(cat 2>/dev/null || true)"
 # Cheap prefilter before paying python3 startup: must mention a file_path at all.
 case "$hook_input" in *'"file_path"'*) ;; *) exit 0 ;; esac
 
-# NB: program via -c (command substitution), NOT `python3 - << heredoc` — a
-# heredoc would override the pipe as stdin and json.load would read EOF.
-printf '%s' "$hook_input" | python3 -c "$(cat << 'PYEOF'
+# NB: payload delivered via env var (HOOK_INPUT), not stdin — that frees stdin
+# so the program can be fed through a plain heredoc to `python3 -`. Avoid the
+# `python3 -c "$(cat << heredoc)"` form (a heredoc nested in $(…)): macOS's
+# system bash 3.2 doesn't skip heredoc bodies when scanning for the closing `)`,
+# so the Python source's quotes parse as shell and abort with a syntax error.
+# See issue #13.
+HOOK_INPUT="$hook_input" python3 - "$REPO_ROOT" <<'PYEOF'
 import datetime, json, os, sys, tempfile
 
 try:
@@ -28,7 +32,7 @@ except ImportError:  # non-POSIX: degrade to unlocked (still atomic via os.repla
 
 root = sys.argv[1]
 try:
-    payload = json.load(sys.stdin)
+    payload = json.loads(os.environ.get("HOOK_INPUT", "") or "{}")
 except Exception:
     sys.exit(0)
 file_path = (payload.get("tool_input") or {}).get("file_path") or ""
@@ -97,6 +101,5 @@ except BaseException:
         pass
     raise
 PYEOF
-)" "$REPO_ROOT"
 
 exit 0

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -1,0 +1,62 @@
+#!/bin/zsh
+set -e
+ENG="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+fail() { echo "FAIL: $1"; exit 1; }
+
+HOOK_SRC="$ENG/hardened/hooks/log-mutation.sh"
+[ -f "$HOOK_SRC" ] || fail "log-mutation.sh source missing"
+
+# --- Regression guard for issue #13 (cross-platform) -------------------------
+# The hook must NOT build its Python via a heredoc nested in $() (`-c "$(cat
+# << ...)"`). macOS's system bash 3.2 does not skip heredoc bodies when scanning
+# for the closing `)`, so that form is a parse error there (CI runs bash 4+, so
+# CI never caught it). This static guard fires on ANY platform.
+# (Strip comment lines first so the explanatory comment in the hook, which
+# names the anti-pattern, doesn't trip the guard on itself.)
+has_antipattern() {  # $1 = file
+  grep -Ev '^[[:space:]]*#' "$1" | grep -Eq -- '-c[[:space:]]+"\$\(cat'
+}
+if has_antipattern "$HOOK_SRC"; then
+  fail "log-mutation.sh uses the heredoc-in-\$() anti-pattern (breaks bash 3.2; see #13)"
+fi
+# Self-test: the guard must actually fire on the bad pattern, not be vacuous.
+PLANT="$TMP/plant.sh"; printf 'python3 -c "$(cat << EOF\nEOF\n)"\n' > "$PLANT"
+if ! has_antipattern "$PLANT"; then
+  fail "anti-pattern guard is vacuous (did not match a planted heredoc-in-\$())"
+fi
+
+# --- Functional test under system bash --------------------------------------
+# Prefer /bin/bash explicitly (3.2 on macOS — the version that regressed). The
+# hook computes REPO_ROOT as ../../ from its own location, so install it under a
+# fake vault's .claude/hooks/ and point the payload at a typed note in it.
+BASH_BIN="/bin/bash"; [ -x "$BASH_BIN" ] || BASH_BIN="$(command -v bash)"
+VAULT="$TMP/vault"
+mkdir -p "$VAULT/.claude/hooks" "$VAULT/Ops/Tasks" "$VAULT/Inbox"
+cp "$HOOK_SRC" "$VAULT/.claude/hooks/log-mutation.sh"
+printf '# Log\n\npreamble\n' > "$VAULT/log.md"
+HOOK="$VAULT/.claude/hooks/log-mutation.sh"
+
+run_hook() {  # $1 = file_path; feeds a PostToolUse-shaped payload on stdin
+  printf '%s' '{"tool_input":{"file_path":"'"$1"'"}}' | "$BASH_BIN" "$HOOK"
+}
+
+# Typed note -> exit 0 and a placeholder prepended (above the preamble's top
+# log line, but the count is what matters here).
+run_hook "$VAULT/Ops/Tasks/x.md" || fail "hook exited non-zero on a typed note (parse error?)"
+[ "$(grep -c 'auto-placeholder' "$VAULT/log.md")" -eq 1 ] || fail "no placeholder appended for typed note"
+grep -q '\[\[x\]\]' "$VAULT/log.md" || fail "placeholder missing the [[x]] wikilink"
+
+# Dedupe: an immediate second Edit to the same note must NOT add a 2nd line.
+run_hook "$VAULT/Ops/Tasks/x.md" || fail "hook exited non-zero on dedupe path"
+[ "$(grep -c 'auto-placeholder' "$VAULT/log.md")" -eq 1 ] || fail "dedupe failed: duplicate placeholder"
+
+# Non-typed locations and the log itself must be skipped (still exit 0).
+run_hook "$VAULT/Inbox/note.md" || fail "hook exited non-zero on Inbox skip"
+run_hook "$VAULT/log.md"        || fail "hook exited non-zero on log.md skip"
+[ "$(grep -c 'auto-placeholder' "$VAULT/log.md")" -eq 1 ] || fail "skipped paths still mutated log.md"
+
+# Empty / file_path-less payloads must be skipped by the prefilter (exit 0).
+printf '%s' '{"tool_input":{}}' | "$BASH_BIN" "$HOOK" || fail "hook exited non-zero on payload without file_path"
+
+echo "PASS: log-mutation hook (bash $("$BASH_BIN" --version | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1))"


### PR DESCRIPTION
Fixes #13.

## Problem

`hardened/hooks/log-mutation.sh` built its Python program with a **heredoc nested inside `$()`** command substitution. macOS's system bash 3.2 doesn't skip heredoc bodies when scanning for the closing `)` of `$(`, so it parsed the Python source as shell — the unbalanced single quotes inside (`timespec='seconds'`, apostrophes) left it "looking for matching `'`" until EOF and it aborted with a syntax error **before python3 ever ran**.

Net effect on stock macOS: the `PostToolUse` hook silently never fired, so the "every Edit/Write auto-appends a `log.md` placeholder" safety net was dead, and every typed-note Edit/Write emitted two stderr lines. Linux/Homebrew bash 4+ parse the old form fine (fixed in bash 4.x), which is why CI never caught it.

## Fix

Adopt the issue's preferred approach — deliver the payload via the **`HOOK_INPUT` env var** instead of stdin, freeing stdin so the program runs from a **plain heredoc** to `python3 -`. This dodges both the bash 3.2 parser bug *and* the original stdin clash the `$()`-heredoc form was working around. Two source changes (program delivery + `json.loads(os.environ[...])` instead of `json.load(sys.stdin)`); program logic is otherwise byte-for-byte unchanged.

## Regression test

Adds `tests/test_hooks.sh`, wired into the maintainer test gate in the README:
- Runs the hook under `/bin/bash` and asserts exit 0 + placeholder prepended + dedupe + skip (Inbox / `log.md` / no-`file_path`) behavior.
- **Statically forbids** the heredoc-in-`$()` form (with a self-test proving the guard isn't vacuous). This guard is cross-platform, so it fires even on Linux CI where bash 4+ would otherwise hide the bug.

## Verification

```
$ printf '%s' '{"tool_input":{"file_path":"'"$PWD"'/Ops/Tasks/x.md"}}' \
    | /bin/bash hardened/hooks/log-mutation.sh ; echo "exit=$?"
exit=0            # was: parse error, exit=2
```

- `/bin/bash` is **3.2.57** on the test machine (the exact frozen Apple bash from the report); `bash -n` parses cleanly on both 3.2 and 5.3.
- `tests/test_hooks.sh`, `tests/test_init.sh`, `tests/test_update.sh`, and `python3 -m unittest` (50 tests) all pass.

## Maintainer note — propagate to the source vault

`hardened/hooks/` is **derived** by `tools/derive.py` (it wipes `hardened/hooks/` and re-copies from `SRC/.claude/hooks/`). This PR fixes the committed engine artifact that users install, but the **source vault's `.claude/hooks/log-mutation.sh` needs the same two-line change**, or the next `derive.py` run reintroduces the bug. `tests/test_hooks.sh` is the backstop: its static guard fails the maintainer gate if a re-derive brings the old pattern back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)