### PR TITLE
Add Linux/WSL2 systemd durable-serve (parallel to macOS launchd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,14 @@ so several can run at once. To serve durably (auto-start at login, survive sleep
   ```
   Both are pre-baked with this vault's path and port; each carries a per-vault id so multiple
   vaults' services don't collide. The systemd unit reuses `scripts/serve_quartz.sh` (which sources
-  nvm), so Node ≥ 22 must be your nvm default.
+  nvm), so Node ≥ 22 must be your nvm default. Logs go to the journal — `journalctl --user -u "$unit"`
+  (the macOS plist writes `outputs/quartz-serve.log` instead).
+
+  On **WSL2**, `systemctl` works only if systemd is enabled: put `systemd=true` under a `[boot]`
+  section in `/etc/wsl.conf`, then `wsl --shutdown` from Windows and reopen the distro. Without it the
+  commands above fail with "System has not been booted with systemd as init system." If `systemctl
+  --user` reports "Failed to connect to bus" over SSH or in a fresh shell, the user manager isn't up
+  yet — the `enable-linger` above starts it; reopen the shell if needed.
 
 ## Updating an installed vault
 

--- a/tests/test_init.sh
+++ b/tests/test_init.sh
@@ -108,6 +108,18 @@ SPACE_UNIT="$TMP/core with spaces/scripts/systemd/memex-quartz.${SPACE_LAUNCHD_I
 SPACE_EXEC="ExecStart=/usr/bin/env bash \"$TMP/core with spaces/scripts/serve_quartz.sh\""
 grep -qF "$SPACE_EXEC" "$SPACE_UNIT" \
   || fail "space-path systemd ExecStart should quote the baked script path"
+
+# Regression: systemd reads % in directive values (ExecStart=/WorkingDirectory=)
+# as a unit specifier, so a literal % from the vault path must be baked as %% or
+# the unit fails to load ("Failed to resolve unit specifiers").
+"$ENG/bin/memex-init" --target "$TMP/core%pct" --packs core --answers "$ENG/tests/fixtures/answers.core.json" >/dev/null
+PCT_LAUNCHD_ID="$(python3 -c "import re; print(re.sub(r'[^A-Za-z0-9]', '-', '$TMP/core%pct').lstrip('-'))")"
+PCT_UNIT="$TMP/core%pct/scripts/systemd/memex-quartz.${PCT_LAUNCHD_ID}.service"
+[ -f "$PCT_UNIT" ] || fail "percent-path systemd unit missing/misnamed"
+grep -qF "ExecStart=/usr/bin/env bash \"$TMP/core%%pct/scripts/serve_quartz.sh\"" "$PCT_UNIT" \
+  || fail "percent-path systemd ExecStart should escape % to %% (else systemd reads it as a specifier)"
+grep -qF "WorkingDirectory=$TMP/core%%pct/quartz" "$PCT_UNIT" \
+  || fail "percent-path systemd WorkingDirectory should escape % to %%"
 # sources config seed: present, default streams (email+slack on, calendar off), local git
 [ -f "$TMP/core/_config/sources.md" ] || fail "_config/sources.md seed missing"
 grep -q "email: { enabled: true" "$TMP/core/_config/sources.md" || fail "email stream not enabled by default"

--- a/tools/derive.py
+++ b/tools/derive.py
@@ -28,7 +28,7 @@ def bake_out(text, pairs):
 # bytes (letterhead .docx, images, fonts). ADD new text formats here — omitting
 # a text format causes its literals to leak un-tokenised into the template. The
 # Task-5 template audit is the backstop that would catch such a leak.
-TEXT_EXTS = {".md", ".ts", ".tsx", ".sh", ".json", ".plist", ".scss", ".py", ".tex", ".sty", ".yaml", ".yml"}
+TEXT_EXTS = {".md", ".ts", ".tsx", ".sh", ".json", ".plist", ".service", ".scss", ".py", ".tex", ".sty", ".yaml", ".yml"}
 
 # One source-resolver per packs.json section. derive and memex_bake's
 # LOCATION_MAP must stay in lockstep: every key here is installed by init via

--- a/tools/memex_bake.py
+++ b/tools/memex_bake.py
@@ -551,14 +551,23 @@ def bake_engine(
     # vaults' services never collide — exactly as the plist filename does.
     systemd = engine_dir / "hardened/systemd"
     if systemd.exists():
+        # systemd treats % in directive values (ExecStart=, WorkingDirectory=,
+        # Description=, ...) as a unit specifier, so a literal % from a baked
+        # value — e.g. a vault under /home/u/100%memex — would make the unit
+        # fail to load ("Failed to resolve unit specifiers ... Invalid slot").
+        # Double % to %% in the substituted VALUES only; the template's own text
+        # is untouched, so any intentional %h/%i specifier an author writes there
+        # still survives.
+        systemd_normalized = {k: v.replace("%", "%%") for k, v in normalized.items()}
         for fp in systemd.iterdir():
             if fp.is_file():
                 if fp.suffix == ".service":
                     unit_name = f"memex-quartz.{launchd_id}.service" if launchd_id else "memex-quartz.service"
                     dst = target / "scripts/systemd" / unit_name
+                    bake_file(fp, dst, answers, systemd_normalized)
                 else:
                     dst = target / "scripts/systemd" / fp.name
-                bake_file(fp, dst, answers, normalized)
+                    bake_file(fp, dst, answers, normalized)
                 result.record(dst.relative_to(target), "hardened", fp)
 
     # Hand-curated vault utilities (memex-doctor.sh etc.) — installed flat


### PR DESCRIPTION
## What

The hardened core shipped a macOS **launchd** LaunchAgent to keep the Quartz site up across reboots / sleep-wake, but there was no equivalent for **Linux / WSL2** . This adds a systemd **user-service** template alongside it, wired through the same bake/audit/test machinery.

## How it fits the architecture

- **`hardened/systemd/memex-quartz.service`** — a hand-curated, tokenized user unit. Like `hardened/scripts/`, it lives *outside* `derive.py`'s wipe set, so it survives re-derives and needs no entry in a source vault (contributors don't have one).
- It **reuses the existing `scripts/serve_quartz.sh`** launcher (invoked via `bash`, since systemd units don't get nvm on `PATH`) rather than duplicating the launch logic — and it doesn't edit that derived script, so it's derive-safe.
- The unit filename carries the per-vault **`MEMEX_LAUNCHD_ID`** (path-derived), so multiple vaults' services never collide — exactly as the launchd plist filename does.

## Changes

- `memex_bake.py`: install + bake the unit into `<vault>/scripts/systemd/`; add `.service` to `TEXT_EXTS` so tokens actually substitute.
- `audit_literals.py` / `audit_refs.py`: recognize `.service` so the template is audited (stays AUDIT/REFS CLEAN).
- `derive.py`: comment that `hardened/systemd/` is hand-curated and must not be added to the wipe list.
- `README.md`: document the Linux/WSL2 `systemctl --user` + `enable-linger` enable steps next to the macOS `launchctl` ones.
- `test_init.sh`: assert the unit installs with the path-derived id, is token-free, and points `ExecStart` at this vault's `serve_quartz.sh`.

## Testing

- `audit_literals.py ./packs` and `./hardened` → **AUDIT CLEAN**
- `audit_refs.py .` → **REFS CLEAN**
- `python3 -m unittest` (in `tools/`) → **50 passed**
- New `test_init.sh` assertions verified against a real init (the full `test_init.sh` couldn't be run end-to-end in my Linux dev env because `bin/memex-init` has a `#!/bin/zsh` shebang and the box has no zsh — a pre-existing env limitation, not introduced here).

Verified the baked unit on a real install: correct per-vault name, no unbaked `{{TOKENS}}`, `ExecStart` and `WorkingDirectory` point at the vault, and `serve_quartz.sh` is reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)