### PR TITLE
README: don't promise reading email-attached CVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ You don't learn an app. You just say what you want:
   the idea into a real project, and breaks it into tasks you can actually start.
 - **"Here's a stack of PDFs — turn them into a research topic."** It ingests each one as a source,
   pulls out the threads, and assembles a linked topic page that ties them together.
-- **"Update this letter of recommendation using the new CV in my email."** It finds the CV in your
-  inbox, reads what changed, and redrafts the letter from your prior letters and your history with
-  the person. *(academic-PI pack)*
+- **"Here's an updated CV — refresh this letter of recommendation."** Drop the new CV into the inbox;
+  Memex reads what changed and redrafts the letter from your prior letters and your history with the
+  person. *(academic-PI pack)*
 - **"Where did we leave off?"** / **"Give me today's briefing."** A daily dashboard of what's due,
   what's blocked, what came in over email and Slack, and the best next move.
 


### PR DESCRIPTION
## What

Reframes the "update this letter of recommendation" example in the README's "say what you want" list.

**Before:**
> **"Update this letter of recommendation using the new CV in my email."** It finds the CV in your inbox, reads what changed, and redrafts the letter…

**After:**
> **"Here's an updated CV — refresh this letter of recommendation."** Drop the new CV into the inbox; Memex reads what changed and redrafts the letter…

## Why

Code review flagged that the example promised Memex can read a CV attached to an email. The actual `draft-letter` skill ([`packs/pi/skills/draft-letter/SKILL.md`](packs/pi/skills/draft-letter/SKILL.md) Step 0b) documents the opposite: the Gmail MCP exposes only attachment *metadata* (filename, mimeType, attachmentId), not the bytes — so the agent must stop and ask the user to drop the materials into `Inbox/` before it can read them.

Users following the advertised prompt would hit a manual handoff instead of the documented behavior. The new wording matches the real workflow (drop the CV into the vault inbox, then Memex reads and redrafts) and is consistent with the "Brain-dump into the inbox" framing in the first bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)