### PR TITLE
README: add Claude-Code-driven install as the primary Quickstart path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ You pick what the engine installs at setup:
 
 ## Quickstart
 
+### The easy way — let Claude Code install it
+
+Memex is built to be driven by **[Claude Code](https://claude.com/claude-code)**, and setup is no
+exception: you don't have to run any of the commands below by hand. Clone (or download) this repo, open
+it in Claude Code, and just ask it to install Memex for you:
+
+> "Install Memex for me — stand up a new vault at `~/code/my-vault`."
+
+Claude Code walks you through the setup interview (your name, emails, paths, ports, which packs) and runs
+everything for you. When it's done, **open Claude Code in your new vault directory** and start driving
+your own Memex:
+
+```bash
+cd ~/code/my-vault && claude
+```
+
+### Manual setup
+
+Prefer to run it yourself? The same thing, step by step:
+
 ```bash
 # 1. Get the engine
 git clone https://github.com/arjunrajlaboratory/Memex.git

--- a/README.md
+++ b/README.md
@@ -1,27 +1,59 @@
-# memex-engine
+# Memex
 
-The distributable engine behind a [Memex vault](https://github.com/exampleorg/vault): a
-discipline for an LLM-maintained knowledge base plus a librarian agent that grows structure on
-demand. Ships as **packs** you opt into, derived from a real vault but carrying none of its data.
+> "A memex is a device in which an individual stores all his books, records, and communications, and
+> which is mechanized so that it may be consulted with exceeding speed and flexibility. It is an
+> enlarged intimate supplement to his memory."
+>
+> — Vannevar Bush, *As We May Think* (1945)
 
-- **`core` pack** (always): the 24 job-agnostic skills + the core typed-note schemas + templates +
-  workflows + prompts.
-- **`pi` pack** (optional): the academic-PI example — letters / CV / grants (`draft-letter`,
-  `ingest-letters`, `cv-scan`, `cv-build` + the Letter/Grant schemas + CV LaTeX).
-- **hardened core** (always): the three discipline hooks + their `settings.json` wiring, the Quartz
-  static-site + dashboards emitter, the contract template, the vault `.gitignore`, and the
-  durable-serve setup (launchd on macOS, systemd on Linux/WSL2).
+**Memex is a second brain that helps you track your work** — a personal knowledge base that an AI
+agent (Claude Code) actively maintains for you. You talk to it in plain language, or drop files into
+it, and it files, links, researches, drafts, and keeps track of everything so you don't have to hold
+it all in your head.
 
-Instance-specific facts (your name, emails, paths, Drive IDs) live as `{{TOKENS}}` and are baked in
-at setup. See the companion design docs in the source vault (the productization design blueprint and
-`MEMEX_SPECIFICATION.md`).
+You don't learn an app. You just say what you want:
+
+- **"Here are some ideas — file them."** Brain-dump into the inbox (or drop in a folder of notes,
+  screenshots, and PDFs); Memex sorts each item into the right place — an idea, a task, a source, a
+  person — and tells you what it did.
+- **"Turn this idea into a project — research it, then help me execute it."** It researches the
+  outside landscape *and* your own vault, writes up what it found plus a proposed first step, promotes
+  the idea into a real project, and breaks it into tasks you can actually start.
+- **"Here's a stack of PDFs — turn them into a research topic."** It ingests each one as a source,
+  pulls out the threads, and assembles a linked topic page that ties them together.
+- **"Here's an updated CV — refresh this letter of recommendation."** Drop the new CV into the inbox;
+  Memex reads what changed and redrafts the letter from your prior letters and your history with the
+  person. *(academic-PI pack)*
+- **"Where did we leave off?"** / **"Give me today's briefing."** A daily dashboard of what's due,
+  what's blocked, what came in over email and Slack, and the best next move.
+
+Under the hood it's just a folder of plain Markdown notes — typed and cross-linked (projects, tasks,
+people, sources, decisions, ideas) that you fully own: no proprietary format, no lock-in. The guiding
+principle is **capture first, structure on demand** — drop things in whenever they show up and let the
+agent file them later. The same vault also publishes as a browsable, searchable website with live
+dashboards.
+
+## The engine and your vault
+
+This repository is the **engine** — the skills, note types, and tooling that make Memex work. It
+doesn't hold any notes. When you set it up, the engine stands up **your own vault**: a separate folder
+(its own git repo) where your second brain actually lives — your projects, tasks, people, ideas, and
+notes. The engine stays generic; your vault holds your data. As the engine improves, you pull those
+improvements into your vault without disturbing anything that's yours.
+
+You pick what the engine installs at setup:
+
+- **core** (always): everything the second brain needs to run — the skills that capture, file,
+  research, and track your work, plus the note types they use.
+- **pi** (optional): an example tailored to an academic PI — drafting recommendation letters,
+  keeping a CV current, and tracking grants.
 
 ## Quickstart
 
 ```bash
 # 1. Get the engine
-git clone https://github.com/exampleorg/memex-engine.git
-cd memex-engine
+git clone https://github.com/arjunrajlaboratory/Memex.git
+cd Memex
 
 # 2. Stand up your own vault (interactive: asks your name, emails, paths, ports)
 bin/memex-init --target ~/code/my-vault --packs core --interview
@@ -46,10 +78,12 @@ so several can run at once. To serve durably (auto-start at login, survive sleep
   `~/Library/LaunchAgents/` and `launchctl bootstrap gui/$(id -u) <plist>`.
 - **Linux / WSL2** — install the systemd user service in `<vault>/scripts/systemd/`:
   ```bash
-  cp <vault>/scripts/systemd/memex-quartz.*.service ~/.config/systemd/user/
+  unit="memex-quartz.<vault-id>.service"  # use the filename in <vault>/scripts/systemd/
+  mkdir -p ~/.config/systemd/user
+  cp "<vault>/scripts/systemd/$unit" ~/.config/systemd/user/
   loginctl enable-linger "$USER"          # run without an active login (and after the WSL VM boots)
   systemctl --user daemon-reload
-  systemctl --user enable --now memex-quartz.*.service
+  systemctl --user enable --now "$unit"
   ```
   Both are pre-baked with this vault's path and port; each carries a per-vault id so multiple
   vaults' services don't collide. The systemd unit reuses `scripts/serve_quartz.sh` (which sources

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ demand. Ships as **packs** you opt into, derived from a real vault but carrying 
 - **`pi` pack** (optional): the academic-PI example — letters / CV / grants (`draft-letter`,
   `ingest-letters`, `cv-scan`, `cv-build` + the Letter/Grant schemas + CV LaTeX).
 - **hardened core** (always): the three discipline hooks + their `settings.json` wiring, the Quartz
-  static-site + dashboards emitter, the contract template, the vault `.gitignore`, the launchd
-  durable-serve setup.
+  static-site + dashboards emitter, the contract template, the vault `.gitignore`, and the
+  durable-serve setup (launchd on macOS, systemd on Linux/WSL2).
 
 Instance-specific facts (your name, emails, paths, Drive IDs) live as `{{TOKENS}}` and are baked in
 at setup. See the companion design docs in the source vault (the productization design blueprint and
@@ -40,8 +40,20 @@ files were installed in `.memex/manifest.json`. Framework files are engine-owned
 put durable local preferences in `_config/overrides.md` (or `_config/sources.md` for stream settings).
 If you edit a framework file in place, Memex treats that as a local fork and the update flow will
 surface it for merge/choice instead of silently overwriting it. Each vault uses a distinct Quartz port
-so several can run at once. To serve durably (auto-start at login, survive sleep), install the LaunchAgent in
-`<vault>/scripts/launchd/` (copy the plist to `~/Library/LaunchAgents/` and `launchctl bootstrap`).
+so several can run at once. To serve durably (auto-start at login, survive sleep):
+
+- **macOS** — install the LaunchAgent in `<vault>/scripts/launchd/`: copy the plist to
+  `~/Library/LaunchAgents/` and `launchctl bootstrap gui/$(id -u) <plist>`.
+- **Linux / WSL2** — install the systemd user service in `<vault>/scripts/systemd/`:
+  ```bash
+  cp <vault>/scripts/systemd/memex-quartz.*.service ~/.config/systemd/user/
+  loginctl enable-linger "$USER"          # run without an active login (and after the WSL VM boots)
+  systemctl --user daemon-reload
+  systemctl --user enable --now memex-quartz.*.service
+  ```
+  Both are pre-baked with this vault's path and port; each carries a per-vault id so multiple
+  vaults' services don't collide. The systemd unit reuses `scripts/serve_quartz.sh` (which sources
+  nvm), so Node ≥ 22 must be your nvm default.
 
 ## Updating an installed vault
 

--- a/hardened/quartz/quartz.layout.ts
+++ b/hardened/quartz/quartz.layout.ts
@@ -38,7 +38,6 @@ export const defaultContentPageLayout: PageLayout = {
         { Component: Component.ReaderMode() },
       ],
     }),
-    Component.DashboardsNav(),
     Component.Explorer(),
   ],
   right: [
@@ -63,7 +62,6 @@ export const defaultListPageLayout: PageLayout = {
         { Component: Component.Darkmode() },
       ],
     }),
-    Component.DashboardsNav(),
     Component.Explorer(),
   ],
   right: [],

--- a/hardened/systemd/memex-quartz.service
+++ b/hardened/systemd/memex-quartz.service
@@ -22,7 +22,7 @@ WorkingDirectory={{VAULT_PATH}}/quartz
 # get nvm on PATH) and exec's `npm run site:serve`. It's invoked via bash — its
 # #!/bin/zsh shebang serves the macOS launchd path, but the body is bash- (and
 # bash-3.2-) compatible, and `bash <file>` ignores the shebang.
-ExecStart=/usr/bin/env bash {{VAULT_PATH}}/scripts/serve_quartz.sh
+ExecStart=/usr/bin/env bash "{{VAULT_PATH}}/scripts/serve_quartz.sh"
 # Keep it alive across crashes / sleep-wake, mirroring launchd KeepAlive.
 Restart=on-failure
 RestartSec=5

--- a/hardened/systemd/memex-quartz.service
+++ b/hardened/systemd/memex-quartz.service
@@ -1,0 +1,31 @@
+[Unit]
+# Linux/WSL2 equivalent of the macOS launchd LaunchAgent
+# (hardened/launchd/com.you.memex-quartz.plist): a durable user service that
+# keeps the local Quartz site at http://localhost:{{QUARTZ_PORT}} up across
+# reboots / sleep-wake, independent of any terminal or Claude Code session.
+#
+# The unit name carries the per-vault id ({{MEMEX_LAUNCHD_ID}}) so a second
+# vault's service never collides with the first — exactly like the launchd Label.
+Description=Memex Quartz site ({{MEMEX_LAUNCHD_ID}}) — http://localhost:{{QUARTZ_PORT}}
+Documentation=https://quartz.jzhao.xyz/
+After=network-online.target
+Wants=network-online.target
+# Don't thrash if it can't start (e.g. node_modules missing, port taken):
+# give up after 5 starts in 60s. Mirrors launchd's ThrottleInterval guard.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory={{VAULT_PATH}}/quartz
+# Reuse the shared launcher: serve_quartz.sh sources nvm (systemd units don't
+# get nvm on PATH) and exec's `npm run site:serve`. It's invoked via bash — its
+# #!/bin/zsh shebang serves the macOS launchd path, but the body is bash- (and
+# bash-3.2-) compatible, and `bash <file>` ignores the shebang.
+ExecStart=/usr/bin/env bash {{VAULT_PATH}}/scripts/serve_quartz.sh
+# Keep it alive across crashes / sleep-wake, mirroring launchd KeepAlive.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/tests/test_init.sh
+++ b/tests/test_init.sh
@@ -88,6 +88,13 @@ grep -q "com.memex.quartz.${CORE_LAUNCHD_ID}" "$CORE_PLIST" || fail "plist Label
 # VAULT_PATH is derived from --target (fixture says /tmp/example-vault; init overrides)
 grep -q "$TMP/core/scripts/serve_quartz.sh" "$CORE_PLIST" \
   || fail "plist VAULT_PATH not derived from --target"
+# Linux durable-serve: the systemd unit carries the same path-derived id, is
+# token-free, and points ExecStart at this vault's serve_quartz.sh.
+CORE_UNIT="$TMP/core/scripts/systemd/memex-quartz.${CORE_LAUNCHD_ID}.service"
+[ -f "$CORE_UNIT" ] || fail "systemd unit missing/misnamed (should carry path-derived id)"
+grep -q "$TMP/core/scripts/serve_quartz.sh" "$CORE_UNIT" \
+  || fail "systemd unit ExecStart not derived from --target"
+grep -q "{{" "$CORE_UNIT" && fail "systemd unit has unbaked {{TOKENS}}" || true
 # sources config seed: present, default streams (email+slack on, calendar off), local git
 [ -f "$TMP/core/_config/sources.md" ] || fail "_config/sources.md seed missing"
 grep -q "email: { enabled: true" "$TMP/core/_config/sources.md" || fail "email stream not enabled by default"

--- a/tests/test_init.sh
+++ b/tests/test_init.sh
@@ -94,7 +94,20 @@ CORE_UNIT="$TMP/core/scripts/systemd/memex-quartz.${CORE_LAUNCHD_ID}.service"
 [ -f "$CORE_UNIT" ] || fail "systemd unit missing/misnamed (should carry path-derived id)"
 grep -q "$TMP/core/scripts/serve_quartz.sh" "$CORE_UNIT" \
   || fail "systemd unit ExecStart not derived from --target"
+CORE_EXEC="ExecStart=/usr/bin/env bash \"$TMP/core/scripts/serve_quartz.sh\""
+grep -qF "$CORE_EXEC" "$CORE_UNIT" \
+  || fail "systemd unit ExecStart should quote the baked script path"
 grep -q "{{" "$CORE_UNIT" && fail "systemd unit has unbaked {{TOKENS}}" || true
+
+# Regression: systemd splits ExecStart on whitespace, so vault paths containing
+# spaces must be baked as one quoted argv item.
+"$ENG/bin/memex-init" --target "$TMP/core with spaces" --packs core --answers "$ENG/tests/fixtures/answers.core.json" >/dev/null
+SPACE_LAUNCHD_ID="$(python3 -c "import re; print(re.sub(r'[^A-Za-z0-9]', '-', '$TMP/core with spaces').lstrip('-'))")"
+SPACE_UNIT="$TMP/core with spaces/scripts/systemd/memex-quartz.${SPACE_LAUNCHD_ID}.service"
+[ -f "$SPACE_UNIT" ] || fail "space-path systemd unit missing/misnamed"
+SPACE_EXEC="ExecStart=/usr/bin/env bash \"$TMP/core with spaces/scripts/serve_quartz.sh\""
+grep -qF "$SPACE_EXEC" "$SPACE_UNIT" \
+  || fail "space-path systemd ExecStart should quote the baked script path"
 # sources config seed: present, default streams (email+slack on, calendar off), local git
 [ -f "$TMP/core/_config/sources.md" ] || fail "_config/sources.md seed missing"
 grep -q "email: { enabled: true" "$TMP/core/_config/sources.md" || fail "email stream not enabled by default"

--- a/tools/audit_literals.py
+++ b/tools/audit_literals.py
@@ -22,7 +22,7 @@ SKIP_DIRS = {".git", "node_modules", "public", ".quartz-cache", "_archive", "Raw
 # log.md is history; the other two are pure data/lockfiles whose long hashes are
 # noise for the drive_id detector (npm integrity hashes, base64 emoji PNGs).
 SKIP_FILES = {"log.md", "package-lock.json", "emojimap.json"}
-TEXT_EXT = {".md", ".ts", ".tsx", ".sh", ".json", ".plist", ".py", ".scss", ".tex", ".sty", ".yaml", ".yml"}
+TEXT_EXT = {".md", ".ts", ".tsx", ".sh", ".json", ".plist", ".service", ".py", ".scss", ".tex", ".sty", ".yaml", ".yml"}
 TEXT_NAMES = {"gitignore", ".gitignore"}  # covers engine's extensionless hardened/gitignore and dot-prefixed .gitignore files
 
 def covered_literals(manifest):

--- a/tools/audit_refs.py
+++ b/tools/audit_refs.py
@@ -16,7 +16,7 @@ Exit 0 with "REFS CLEAN: ..." or list "REF PROBLEMS (n):" and exit 1.
 """
 import json, os, pathlib, re, sys
 
-TEXT_EXT = {".md", ".ts", ".tsx", ".sh", ".json", ".plist", ".py", ".scss", ".tex", ".sty", ".yaml", ".yml"}
+TEXT_EXT = {".md", ".ts", ".tsx", ".sh", ".json", ".plist", ".service", ".py", ".scss", ".tex", ".sty", ".yaml", ".yml"}
 TEXT_NAMES = {"gitignore", ".gitignore"}
 SKIP_DIRS = {".git", "node_modules", "public", ".quartz-cache", "__pycache__", ".venv"}
 TOKEN_RE = re.compile(r"\{\{([A-Z0-9_]+)\}\}")

--- a/tools/derive.py
+++ b/tools/derive.py
@@ -134,8 +134,9 @@ def main():
 
     # Wipe only what derive regenerates. packs/ is fully derived. Under hardened/,
     # the hooks/launchd/quartz dirs + settings.json/gitignore files are derived —
-    # but hardened/contract/ AND hardened/scripts/ (memex-doctor.sh) are
-    # HAND-CURATED and must survive re-derives.
+    # but hardened/contract/, hardened/scripts/ (memex-doctor.sh), AND
+    # hardened/systemd/ (the Linux durable-serve unit) are HAND-CURATED and must
+    # survive re-derives, so they are deliberately absent from the wipe list below.
     shutil.rmtree(ENG / "packs", ignore_errors=True)
     for sub in ("hooks", "launchd", "quartz"):
         shutil.rmtree(ENG / "hardened" / sub, ignore_errors=True)

--- a/tools/memex_bake.py
+++ b/tools/memex_bake.py
@@ -29,6 +29,7 @@ TEXT_EXTS = {
     ".sh",
     ".json",
     ".plist",
+    ".service",
     ".scss",
     ".py",
     ".tex",
@@ -541,6 +542,22 @@ def bake_engine(
                     dst = target / "scripts/launchd" / plist_name
                 else:
                     dst = target / "scripts" / fp.name
+                bake_file(fp, dst, answers, normalized)
+                result.record(dst.relative_to(target), "hardened", fp)
+
+    # Linux/WSL2 durable-serve: the systemd user-service equivalent of the macOS
+    # launchd plist above. Hand-curated (like hardened/scripts/), so it's not
+    # derived/wiped. The unit filename carries the path-derived vault id so two
+    # vaults' services never collide — exactly as the plist filename does.
+    systemd = engine_dir / "hardened/systemd"
+    if systemd.exists():
+        for fp in systemd.iterdir():
+            if fp.is_file():
+                if fp.suffix == ".service":
+                    unit_name = f"memex-quartz.{launchd_id}.service" if launchd_id else "memex-quartz.service"
+                    dst = target / "scripts/systemd" / unit_name
+                else:
+                    dst = target / "scripts/systemd" / fp.name
                 bake_file(fp, dst, answers, normalized)
                 result.record(dst.relative_to(target), "hardened", fp)
 


### PR DESCRIPTION
## What

Adds an **"easy way"** subsection at the top of the Quickstart, since Memex is built to be driven by Claude Code:

- Clone/open the engine repo in Claude Code and just ask it to install Memex (no manual commands).
- Claude Code runs the setup interview for you.
- When done, open Claude Code in the new vault directory to drive your own Memex.

The existing `bin/memex-init` bash steps are retained under a **"Manual setup"** subsection for those who prefer to run it themselves.

## Why

The whole point of Memex is that you drive it by talking to an agent — so the install story should lead with that, not with hand-run shell commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)