### PR TITLE
mail skills: add stale-read axis to mailbox truth model

### DIFF
--- a/docs/superpowers/specs/2026-06-04-default-multi-source-loop-closing-design.md
+++ b/docs/superpowers/specs/2026-06-04-default-multi-source-loop-closing-design.md
@@ -41,6 +41,14 @@ git mode.
    account visible. Non-connected sending accounts must be modeled explicitly and a
    sent-mail miss for them is inconclusive, not evidence of "not sent."
 
+   > **Addendum (later finding — orthogonal axis).** `search_threads` is *not* fully
+   > authoritative even for the connected mailbox: its index can be **stale** (observed
+   > days behind reality, and unrefreshed by re-running the same search). Search is for
+   > *locating* candidate threads only; `get_thread(threadId)` is the live ground truth
+   > for a thread's latest state and whether a message exists. An empty search is
+   > therefore "couldn't confirm," never "not sent" — for every user, regardless of how
+   > many accounts they have. See memory `feedback_gmail_mcp_stale_reads`.
+
 ## Architecture
 
 The briefing becomes the conductor; the existing skills stay the instruments.

--- a/packs/core/prompts/daily-briefing.md
+++ b/packs/core/prompts/daily-briefing.md
@@ -37,9 +37,11 @@ for enabled streams and `mailboxes.*`. Run `capture-comms` for {{date}}, then
 old. Tier-A reversible bookkeeping auto-applies; Tier-B proposals become `## 0. State
 confirmation needed` and are confirmed in one batch after the briefing. The Gmail MCP
 searches only `mailboxes.gmail_connected`: sent mail from `mailboxes.forwarding_in` or
-`mailboxes.other_sending_accounts` is invisible unless separately connected. For
-outbound-contact tasks, an empty connected-mailbox `in:sent` result is inconclusive,
-not proof of "not sent"; phrase those items as "couldn't confirm from connected Gmail"
+`mailboxes.other_sending_accounts` is invisible unless separately connected. Separately,
+`search_threads` can lag the connected mailbox itself (a stale cached view, days behind and
+unrefreshed by repeating the search). For outbound-contact tasks, an empty connected-mailbox
+`in:sent` result is inconclusive either way, not proof of "not sent"; confirm a specific thread
+with `get_thread(threadId)`, phrase unconfirmed items as "couldn't confirm from connected Gmail,"
 and ask the user.
 
 Gather the following inputs (read only what exists; skip gracefully if absent):

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -142,6 +142,13 @@ received. Received comms more often *open* loops (someone asks you for something
      `feedback_gmail_search_technique`). For sends from non-connected accounts, an empty `in:sent`
      result is an access gap and must be labeled **couldn't confirm**, not "not sent" or
      "awaiting send."
+   - **`search_threads` can be stale — separate from visibility.** The search index can sit days
+     behind reality even for the connected mailbox, and re-running the same query does not refresh
+     it. So an empty `in:sent` is never proof a send didn't happen, even when no other account is in
+     play: confirm a specific thread's latest state with `get_thread(threadId)` (live ground truth),
+     and label any unconfirmed send **couldn't confirm** — never "not sent" / "awaiting send." If the
+     user says they sent it, believe them and capture the loop accordingly (memory
+     `feedback_gmail_mcp_stale_reads`).
 
 4. **Scan Slack — both directions, including what I sent** (only if `slack` is enabled per Step 0).
    - Resolve the user's own Slack identity first (`slack_read_user_profile` /
@@ -211,4 +218,4 @@ Phase 1 (this skill) **never** does step 2 or 3. It only produces step 1's input
 - [[email]] — the broad-search technique + Gmail query cheat-sheet this reuses.
 - [[triage-inbox]] — consumes `Inbox/` items, including the `## Threads worth routing` entries.
 - `Daily comms digest and automated loop-closing` (idea) — full design rationale + phase 2 spec.
-- Memories: `feedback_gmail_search_technique` (search broadly first).
+- Memories: `feedback_gmail_search_technique` (search broadly first), `feedback_gmail_mcp_stale_reads` (search index can lag reality — confirm with `get_thread`).

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -90,6 +90,7 @@ Mirror cv-scan's checkbox + provenance block exactly, so phase 2 can parse it de
 ```markdown
 - [ ] **<one-line description of the loop>**
       ↳ signal: <sent email to Alex / Slack DM I sent to Jordan / received from Riley>  ·  <date/time>
+      ↳ thread: <Gmail `threadId` for email items — lets phase 2 confirm via `get_thread` without re-searching; `n/a` for Slack>
       ↳ likely target: [[<Task or Person or Letter or Followup>]] (<type>)  — or `(no obvious target)`
       ↳ suggested action: <close task | bump last_contact | flip Letter drafting→submitted | mark Followup acted_on | create task>
       ↳ confidence: high | medium | low
@@ -132,7 +133,9 @@ received. Received comms more often *open* loops (someone asks you for something
      threads that skip the inbox).
    - **Sent: `in:sent newer_than:<window>`** — the loop-closing gold. What did *I* send today?
    - For any thread that looks loop-relevant, `get_thread` with `messageFormat: FULL_CONTENT` to
-     read the actual chain before classifying (snippets hide the substance).
+     read the actual chain before classifying (snippets hide the substance). Record that thread's
+     `threadId` in the action item's `↳ thread:` field so phase-2 reconcile can re-confirm via
+     `get_thread` without re-searching a possibly-stale index.
    - Mailbox visibility: the Gmail MCP searches only the connected mailbox, `{{OWNER_PRIMARY_EMAIL}}`{{?OWNER_FORWARDING_EMAIL}}.
      `{{OWNER_FORWARDING_EMAIL}}` forwards received mail into it, but sent mail from that address
      is invisible unless it was also sent through the connected mailbox{{/OWNER_FORWARDING_EMAIL}}{{?OWNER_SENDING_ACCOUNTS}}.

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -85,7 +85,7 @@ phase: 1-capture-only          # APPLIES NOTHING; phase 2 reconciles
 
 ### Action item format (the phase-2 API — keep it parseable)
 
-Mirror cv-scan's checkbox + provenance block exactly, so phase 2 can parse it deterministically:
+Mirror cv-scan's checkbox + provenance shape (one parseable `↳ key: value` line per field) so phase 2 can parse it deterministically:
 
 ```markdown
 - [ ] **<one-line description of the loop>**

--- a/packs/core/skills/daily-briefing/SKILL.md
+++ b/packs/core/skills/daily-briefing/SKILL.md
@@ -56,6 +56,8 @@ Tasks that Tier-A already advanced will read correctly through the rest of the b
 
 If the contact/send status depends on mail that may have been sent from a non-connected account, the comms pass can only return an **inconclusive** prompt ("couldn't confirm from connected Gmail; did this go from <account>?"). Never convert an empty connected-mailbox `in:sent` result into "not sent" / "awaiting send" when the relevant thread may live in `mailboxes.other_sending_accounts` or the forwarding-in account's own sent folder.
 
+There is a second, orthogonal reason never to read "not sent" off an empty search: `search_threads` can return a **stale** snapshot of the connected mailbox *itself* — observed days behind reality, and unchanged by re-running the same query — so an empty `in:sent` is not proof a send didn't happen even when no other account is in play. Confirm a specific thread with `get_thread(threadId)` (live ground truth), cap an unconfirmed send at "couldn't confirm," and if the user says they sent it, believe them and reconcile accordingly.
+
 ## Step 2 — Gather inputs (in parallel)
 
 Run these reads in parallel — one message, multiple tool calls. Read only what exists; skip gracefully if a folder is absent.
@@ -82,7 +84,7 @@ Also pull yesterday's briefing's "## Shutdown notes" section if present — it c
 
 When (a) and (b) point at the same note, keep the reconcile proposal (it carries the signal) and drop the duplicate. If Step 1b was skipped (no streams enabled, or the backfill guard fired), § 0 is just (b).
 
-For outbound-contact tasks (reply/send/email/follow-up tasks), do **not** infer "awaiting send" from stale note state alone when email is enabled. Step 1b's live comms capture (or a same-day `Inbox/comms/<date>/` digest) is the prerequisite. If the connected Gmail search missed the send but the task/person uses a non-connected sending account, render the item as "couldn't confirm from connected Gmail — may have gone from <account>" and ask the user, rather than asserting it remains open.
+For outbound-contact tasks (reply/send/email/follow-up tasks), do **not** infer "awaiting send" from stale note state alone when email is enabled. Step 1b's live comms capture (or a same-day `Inbox/comms/<date>/` digest) is the prerequisite. If the connected Gmail search missed the send but the task/person uses a non-connected sending account, render the item as "couldn't confirm from connected Gmail — may have gone from <account>" and ask the user, rather than asserting it remains open. The connected-mailbox search can also be **stale** (the Gmail index lags reality and a repeat search won't refresh it), so a send that search can't see is "couldn't confirm" even without a second account — verify the specific thread with `get_thread(threadId)` before asserting anything, and never emit "awaiting send" / "unsent" off an empty search.
 
 Four pre-flight queries (run in parallel):
 

--- a/packs/core/skills/email/SKILL.md
+++ b/packs/core/skills/email/SKILL.md
@@ -9,7 +9,7 @@ You are running as **`agent:executor`** for this skill (or `agent:capture` when 
 
 ## Why this skill exists
 
-Gmail is already wired into this vault (the Gmail MCP powers `ingest-person` backfill, `draft-letter` seeding, and `daily-briefing` calendar/inbox pulls). But "how to use email" lived only *inside* those skills. The recurring failure modes were (a) concluding "this isn't in Gmail" after a too-narrow query — a **technique** gap, not a capability gap — and (b) treating a miss in the connected mailbox as proof when the user may have sent from another account the Gmail MCP cannot read. See memories `feedback_gmail_search_technique` and `feedback_gmail_penn_mailbox_blind_spot`. This skill is the general, reusable place for email competence so any session can search/read/capture/draft well without reinventing it.
+Gmail is already wired into this vault (the Gmail MCP powers `ingest-person` backfill, `draft-letter` seeding, and `daily-briefing` calendar/inbox pulls). But "how to use email" lived only *inside* those skills. The recurring failure modes were (a) concluding "this isn't in Gmail" after a too-narrow query — a **technique** gap, not a capability gap; (b) treating a miss in the connected mailbox as proof when the user may have sent from another account the Gmail MCP cannot read; and (c) trusting a `search_threads` snapshot as a thread's current state when that index can be **stale** — observed days behind reality, and unchanged by re-running the same search — so only `get_thread` reflects the truth. See memories `feedback_gmail_search_technique` and `feedback_gmail_mcp_stale_reads`. This skill is the general, reusable place for email competence so any session can search/read/capture/draft well without reinventing it.
 
 ## Hard rules (non-negotiable)
 
@@ -53,9 +53,13 @@ Order of operations:
 
 Notes: `search_threads` returns snippets + headers only — **not full bodies**. **Mailbox visibility:** the Gmail MCP searches only the connected mailbox, `{{OWNER_PRIMARY_EMAIL}}`{{?OWNER_FORWARDING_EMAIL}}. `{{OWNER_FORWARDING_EMAIL}}` forwards received mail into it, but sent mail from that address is invisible unless it was also sent through the connected mailbox{{/OWNER_FORWARDING_EMAIL}}{{?OWNER_SENDING_ACCOUNTS}}. Other sending accounts the user may use: `{{OWNER_SENDING_ACCOUNTS}}`; mail sent from those accounts is invisible to this Gmail MCP unless those mailboxes are separately connected{{/OWNER_SENDING_ACCOUNTS}}. For threads expected to be in the connected mailbox, assume a **query miss, not an access gap** until broad content-keyword search fails (memory `feedback_gmail_search_technique`). For mail sent from or housed in a non-connected account, an empty search is **inconclusive access-gap evidence**, not proof that the user did not send it.
 
+**Search can be stale — a separate axis from visibility.** `search_threads` is a possibly-stale cached index: observed days behind reality, and re-running the *same* search does **not** refresh it. This is orthogonal to mailbox visibility — it happens even inside the connected mailbox, for every user. So use search only to **locate** candidate threads; never judge a thread's latest state, or whether a recent message exists, from a search snippet. Confirm with `get_thread` (Step 2), which is live ground truth. A negative/empty search is therefore never proof a message wasn't sent (memory `feedback_gmail_mcp_stale_reads`).
+
 ## Step 2 — Read the actual thread
 
 To get bodies, call `mcp__claude_ai_Gmail__get_thread` with the `threadId` and `messageFormat: FULL_CONTENT`. Read the whole chain (both sides) before summarizing — snippets routinely hide the substance (a "thanks!" snippet can sit on a thread whose body is the actual decision).
+
+`get_thread(threadId)` is also the **authority on a thread's current state** — `search_threads` can lag it by days (see Step 1's stale-search note). So whenever the question is "did they reply?", "did I send it?", or "what's the latest?", decide from `get_thread`, never from a search snippet. If broad search turns up nothing, that is **"couldn't confirm,"** not proof it didn't happen — if the user says they sent it, believe them and reconcile state accordingly. Never emit "unsent (high confidence)" or "awaiting send" off an empty search.
 
 ## Step 3 — Do what was asked
 
@@ -92,4 +96,4 @@ Scheduling lives next door: if the email is about setting a time, the Calendar M
 - `create-task` / followups — action items an email creates.
 - `draft-letter` — letters of rec / cover / nomination (not plain replies).
 - `daily-briefing` — already pulls inbox + calendar; this skill is the on-demand counterpart.
-- Memories: `feedback_gmail_search_technique` (search broadly first), `feedback_enrich_people_from_gmail` (Person backfill).
+- Memories: `feedback_gmail_search_technique` (search broadly first), `feedback_gmail_mcp_stale_reads` (search index can be stale — confirm a thread's state with `get_thread`), `feedback_enrich_people_from_gmail` (Person backfill).

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -39,11 +39,11 @@ pre-flight — it relied on the user remembering; this reads the captured signal
   those accounts, mark it inconclusive and ask the user; never assert "not sent" / "awaiting send."
 - **Stale search reads are not negative evidence either — a separate axis.** `search_threads`
   returns a cached index that can lag reality by days even for the connected mailbox, and re-running
-  the same search does not refresh it. Before any proposal turns on "no sent email found," re-confirm
-  the specific thread with `get_thread(threadId)` (live ground truth) rather than trusting an empty
-  search; an empty search alone is "couldn't confirm," never "not sent" / "awaiting send." If the
-  user says they sent it, believe them and reconcile state accordingly (memory
-  `feedback_gmail_mcp_stale_reads`).
+  the same search does not refresh it. Before any proposal turns on "no sent email found," confirm
+  the specific thread with `get_thread` (live ground truth) — using the digest's recorded `↳ thread:`
+  id, or re-locating the thread by search first — rather than trusting an empty search result; an
+  empty search alone is "couldn't confirm," never "not sent" / "awaiting send." If the user says they
+  sent it, believe them and reconcile state accordingly (memory `feedback_gmail_mcp_stale_reads`).
 - **Honor sensitivity.** Anything the phase-1 file flagged `[sensitive — summarized]` (e.g. a career
   decision) is **always** propose-only and never auto-applied; do not expand the summary or quote it.
   Never lower a note's sensitivity.
@@ -102,12 +102,15 @@ job, and the mark is the idempotency key. For each reconciled item:
    (`ls Atlas/... Ops/Tasks/...` or grep). If it says `(no obvious target)`, this is a *create*
    proposal (Tier B), not an update. If the link is wrong, search by person-name + subject keyword
    (the way `observe-task-actuals` triangulates) before giving up. To confirm an action truly
-   happened, re-read the thread with `get_thread(threadId)` (the authority on current state) — do
-   **not** re-run `search_threads`, whose index can be stale. When re-reading email, first
-   check `_config/sources.md` for mailbox visibility. A miss in connected Gmail can be a query miss
-   *or* a stale-index miss for threads expected there; for non-connected sending accounts it is an
-   access gap. In every case confirm with `get_thread` before concluding, and if the send can't be
-   confirmed make it a Tier-B "couldn't confirm; did this go out?" question — never "not sent."
+   happened, read the live thread with `get_thread(threadId)` (the authority on current state).
+   Use the `↳ thread:` id the phase-1 digest recorded for the email item; if it's missing (older
+   digest, or a Slack-sourced item), re-locate the candidate with `search_threads` first — search
+   *locates*, `get_thread` *confirms* — just never conclude from the search result itself, whose
+   index can be stale. When re-reading email, first check `_config/sources.md` for mailbox
+   visibility. A miss in connected Gmail can be a query miss *or* a stale-index miss for threads
+   expected there; for non-connected sending accounts it is an access gap. In every case confirm
+   with `get_thread` before concluding, and if the send still can't be confirmed make it a Tier-B
+   "couldn't confirm; did this go out?" question — never "not sent."
 
 4. **Classify into Tier A or Tier B** per the table. Demote on low confidence / sensitivity / no match.
 

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -91,8 +91,9 @@ job, and the mark is the idempotency key. For each reconciled item:
 
 1. **Resolve the date + load the files.** Date = today (or the date arg). `ls Inbox/comms/<date>/`.
    If the folder is missing, tell the user to run [[capture-comms]] first and stop. Read every
-   `*.md` there; parse each `## Action items` block (checkbox + the `↳ signal / likely target /
-   suggested action / confidence` fields). Read any existing `## Reconciliation` ledger.
+   `*.md` there; parse each `## Action items` block (checkbox + the `↳ signal / thread / likely
+   target / suggested action / confidence` fields — `thread` is the Gmail `threadId` for email
+   items, used in Step 3 to confirm via `get_thread`). Read any existing `## Reconciliation` ledger.
 
 2. **Merge cross-file duplicates.** The same loop can appear in both `email.md` and `slack.md`
    (e.g. a PR review requested by email + "ran codex" in Slack). Collapse to one reconciliation

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -103,15 +103,20 @@ job, and the mark is the idempotency key. For each reconciled item:
    (`ls Atlas/... Ops/Tasks/...` or grep). If it says `(no obvious target)`, this is a *create*
    proposal (Tier B), not an update. If the link is wrong, search by person-name + subject keyword
    (the way `observe-task-actuals` triangulates) before giving up. To confirm an action truly
-   happened, read the live thread with `get_thread(threadId)` (the authority on current state).
-   Use the `↳ thread:` id the phase-1 digest recorded for the email item; if it's missing (older
-   digest, or a Slack-sourced item), re-locate the candidate with `search_threads` first — search
-   *locates*, `get_thread` *confirms* — just never conclude from the search result itself, whose
-   index can be stale. When re-reading email, first check `_config/sources.md` for mailbox
-   visibility. A miss in connected Gmail can be a query miss *or* a stale-index miss for threads
-   expected there; for non-connected sending accounts it is an access gap. In every case confirm
-   with `get_thread` before concluding, and if the send still can't be confirmed make it a Tier-B
-   "couldn't confirm; did this go out?" question — never "not sent."
+   happened, re-read the live thread **on its own channel** — confirmation never crosses sources
+   (an item's source is in the digest frontmatter and its `↳ signal`):
+   - **Email items** (`↳ thread:` holds a Gmail `threadId`): read it with `get_thread(threadId)`
+     (the authority on current state). If the id is missing (an older digest), re-locate the
+     candidate with `search_threads` first — search *locates*, `get_thread` *confirms* — just never
+     conclude from the search result itself, whose index can be stale. First check
+     `_config/sources.md` for mailbox visibility: a miss in connected Gmail can be a query miss *or*
+     a stale-index miss for threads expected there; for non-connected sending accounts it is an
+     access gap.
+   - **Slack items** (`↳ thread: n/a`): confirm from the captured Slack signal, or re-read the
+     Slack thread/channel with `slack_read_thread` / `slack_read_channel`. Never route a Slack
+     confirmation through Gmail `search_threads` / `get_thread`.
+   In every case confirm on the right channel before concluding, and if the action still can't be
+   confirmed make it a Tier-B "couldn't confirm; did this happen?" question — never "not sent."
 
 4. **Classify into Tier A or Tier B** per the table. Demote on low confidence / sensitivity / no match.
 

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -37,6 +37,13 @@ pre-flight — it relied on the user remembering; this reads the captured signal
   `mailboxes.forwarding_in` or `mailboxes.other_sending_accounts` is invisible unless those
   mailboxes are separately connected. If a proposal depends on "no sent email found" for one of
   those accounts, mark it inconclusive and ask the user; never assert "not sent" / "awaiting send."
+- **Stale search reads are not negative evidence either — a separate axis.** `search_threads`
+  returns a cached index that can lag reality by days even for the connected mailbox, and re-running
+  the same search does not refresh it. Before any proposal turns on "no sent email found," re-confirm
+  the specific thread with `get_thread(threadId)` (live ground truth) rather than trusting an empty
+  search; an empty search alone is "couldn't confirm," never "not sent" / "awaiting send." If the
+  user says they sent it, believe them and reconcile state accordingly (memory
+  `feedback_gmail_mcp_stale_reads`).
 - **Honor sensitivity.** Anything the phase-1 file flagged `[sensitive — summarized]` (e.g. a career
   decision) is **always** propose-only and never auto-applied; do not expand the summary or quote it.
   Never lower a note's sensitivity.
@@ -94,11 +101,13 @@ job, and the mark is the idempotency key. For each reconciled item:
 3. **Resolve each `likely target` to a real note.** Confirm the wikilink resolves
    (`ls Atlas/... Ops/Tasks/...` or grep). If it says `(no obvious target)`, this is a *create*
    proposal (Tier B), not an update. If the link is wrong, search by person-name + subject keyword
-   (the way `observe-task-actuals` triangulates) before giving up. Re-read the comm thread via the
-   MCP tools only if you need to confirm the action truly happened. When re-reading email, first
-   check `_config/sources.md` for mailbox visibility. A miss in connected Gmail is only a query miss
-   for threads expected there; for non-connected sending accounts it is an access gap and should
-   become a Tier-B "couldn't confirm; did this go from <account>?" question.
+   (the way `observe-task-actuals` triangulates) before giving up. To confirm an action truly
+   happened, re-read the thread with `get_thread(threadId)` (the authority on current state) — do
+   **not** re-run `search_threads`, whose index can be stale. When re-reading email, first
+   check `_config/sources.md` for mailbox visibility. A miss in connected Gmail can be a query miss
+   *or* a stale-index miss for threads expected there; for non-connected sending accounts it is an
+   access gap. In every case confirm with `get_thread` before concluding, and if the send can't be
+   confirmed make it a Tier-B "couldn't confirm; did this go out?" question — never "not sent."
 
 4. **Classify into Tier A or Tier B** per the table. Demote on low confidence / sensitivity / no match.
 

--- a/packs/core/workflows/daily-briefing.md
+++ b/packs/core/workflows/daily-briefing.md
@@ -20,7 +20,10 @@ mail from that address, or from `mailboxes.other_sending_accounts`, is invisible
 mailboxes are separately connected. For outbound-contact tasks, an empty connected-mailbox
 `in:sent` result is therefore **inconclusive**, not evidence of "not sent"; surface it as
 "couldn't confirm from connected Gmail — did this go from another account?" instead of
-"awaiting send."
+"awaiting send." Independently of accounts, `search_threads` can return a **stale** cached view
+of even the connected mailbox — days behind reality, and unrefreshed by repeating the search — so
+confirm a specific thread with `get_thread(threadId)` and never read "not sent" off an empty
+search.
 
 ## Inputs to read
 


### PR DESCRIPTION
## The gap

The Gmail MCP's `search_threads` can return a **stale, cached** view of a thread — observed days behind reality. Re-running the *identical* search returns the same stale snapshot (it does **not** refresh), while `get_thread(threadId)` returns the full, current chain. So a negative/empty search is never proof a message wasn't sent.

Memex already treats an empty `in:sent` as **inconclusive** when mail might live in a non-connected account (the `mailboxes.other_sending_accounts` model). But the stale-read issue is a **separate, orthogonal axis**: it happens even *within* the connected mailbox, for every user, regardless of how many accounts they have. Memex had no concept of it, so a stale-but-present-in-the-connected-mailbox thread was still wrongly read as "not sent."

## The change (additive, template-safe)

Across the mail-reasoning guidance, encode the rule:
1. `search_threads` results can be a stale cached view; re-running the same search does not refresh it — use search only to **locate** candidate threads.
2. To decide sent-vs-unsent or read a thread's true latest state, call `get_thread(threadId)` — the authority. Never decide from a search snippet.
3. An empty/negative result is never proof the user didn't send something. If the user says they sent it, believe them. Cap at "couldn't confirm" with the reason — never "unsent (high confidence)" / "awaiting send."
4. `get_thread` is loaded where it matters (both `ToolSearch select:` lines already include it, unconditionally).

The existing connected-vs-non-connected mailbox model and all `{{OWNER_*}}` / `mailboxes.*` templating are left intact.

## Files

| File | Change |
|---|---|
| `packs/core/skills/email/SKILL.md` | Stale-search axis in rationale + Mailbox-visibility notes + read-the-thread step; renamed memory ref; added to Related. |
| `packs/core/skills/capture-comms/SKILL.md` | Stale-read bullet in the Gmail sent-scan block + Related memories. |
| `packs/core/skills/daily-briefing/SKILL.md` | Extended §0/Step-1b and Step-2b outbound-contact notes to cover stale connected-mailbox reads. |
| `packs/core/skills/reconcile-from-comms/SKILL.md` | "Stale reads are not negative evidence" guardrail; Step 3 confirms via `get_thread`, not re-search. |
| `packs/core/workflows/daily-briefing.md` | Account-independent stale-search caveat. |
| `packs/core/prompts/daily-briefing.md` | Same caveat in the paste prompt. |
| `docs/superpowers/specs/2026-06-04-…-design.md` | Addendum to "Mailbox truth model" item 5 (the one assertion that contradicted the new rule). |

## Stale memory reference

`feedback_gmail_penn_mailbox_blind_spot` (whose "sent from another account" framing was the wrong explanation in practice) → renamed to the generalized **`feedback_gmail_mcp_stale_reads`**. Grep showed it lived in only **one** file (`email/SKILL.md`), not the three the original brief guessed. `feedback_gmail_search_technique` is preserved (still valid). Memex ships no memory files — these are name references only.

## Verification

```
grep feedback_gmail_penn_mailbox_blind_spot .  → no results
audit_literals ./packs / ./hardened            → AUDIT CLEAN
audit_refs .                                    → REFS CLEAN
tools  python3 -m unittest                      → 50 tests OK
tests/test_init.sh                              → PASS
tests/test_hooks.sh                             → PASS
```

> Note: `packs/` is regenerated by `derive.py` from an upstream source vault, so for these prose edits to survive a future re-derive, the same wording should also land in that source vault. The `docs/` spec is hand-curated and not regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)