### PR TITLE
desktop: code signing, release workflow, and distribution docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release Memex Desktop
+
+# Tag a release to build and publish installers:
+#   git tag app-v0.1.0 && git push origin app-v0.1.0
+# Artifacts land on a DRAFT GitHub Release (electron-builder creates it), so the
+# binaries can be checked before anyone can download them — publish the release
+# by hand when it looks right. Use the manual trigger (publish=false) to test the
+# build pipeline without uploading anything.
+#
+# Secrets and Apple setup: docs/RELEASING.md
+on:
+  push:
+    tags:
+      - 'app-v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Upload artifacts to a draft GitHub Release'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write   # electron-builder needs this to create the draft release
+
+env:
+  # Tag pushes always publish; manual runs only when asked.
+  PUBLISH_FLAG: ${{ (github.event_name == 'push' || inputs.publish) && '--publish always' || '--publish never' }}
+
+defaults:
+  run:
+    working-directory: app
+
+jobs:
+  macos:
+    # Signed + notarized when the Apple secrets are present. Without them
+    # electron-builder logs a warning and produces an unsigned build rather than
+    # failing, so forks and secret-less runs still exercise the pipeline.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - run: npm ci
+      # dist:mac runs `npm run build` (tsc + assets) before electron-builder, so
+      # the packaged dist/ is never stale.
+      - name: Build, sign, notarize, publish
+        run: npm run dist:mac -- ${{ env.PUBLISH_FLAG }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Developer ID Application certificate, base64-encoded .p12
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # Notarization credentials. electron-builder reads these from the
+          # environment only — there is no package.json equivalent — and skips
+          # notarization with a warning if they are absent.
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+  windows:
+    # Unsigned for now — users get a SmartScreen warning on first run. To sign,
+    # follow the Azure Trusted Signing section of docs/RELEASING.md and add the
+    # AZURE_* secrets below.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - run: npm ci
+      - name: Build and publish
+        run: npm run dist:win -- ${{ env.PUBLISH_FLAG }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          # AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          # AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - run: npm ci
+      # The unit tests are plain Node (no Electron), so one platform is enough.
+      # Kept on Linux because the `test/*.test.cjs` glob needs a POSIX shell.
+      - run: npm test
+      - name: Build and publish
+        run: npm run dist:linux -- ${{ env.PUBLISH_FLAG }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
     # electron-builder logs a warning and produces an unsigned build rather than
     # failing, so forks and secret-less runs still exercise the pipeline.
     runs-on: macos-latest
+    env:
+      # Exposed at job level so the `if:` below can test it — the `secrets`
+      # context is not available in step-level `if` expressions.
+      APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -44,6 +48,15 @@ jobs:
           cache: npm
           cache-dependency-path: app/package-lock.json
       - run: npm ci
+      # notarytool wants the App Store Connect key as a FILE, and APPLE_API_KEY
+      # must hold its PATH — not the key material. Skipped when the secret is
+      # absent so credential-less runs still build (unsigned, un-notarized).
+      - name: Write App Store Connect API key
+        if: env.APPLE_API_KEY_P8 != ''
+        run: |
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/private_keys/AuthKey.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
       # dist:mac runs `npm run build` (tsc + assets) before electron-builder, so
       # the packaged dist/ is never stale.
       - name: Build, sign, notarize, publish
@@ -55,10 +68,11 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           # Notarization credentials. electron-builder reads these from the
           # environment only — there is no package.json equivalent — and skips
-          # notarization with a warning if they are absent.
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # notarization with a warning if they are absent. APPLE_API_KEY is set
+          # by the step above. Do NOT also set APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD:
+          # the implementation checks those FIRST and would ignore the API key.
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
   windows:
     # Unsigned for now — users get a SmartScreen warning on first run. To sign,

--- a/app/build/entitlements.mac.plist
+++ b/app/build/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Electron/V8 needs JIT and writable-executable pages under the hardened runtime. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Electron loads framework dylibs that are not signed by this team. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- The Claude Code hand-off drives Terminal.app through osascript, which is an
+         Apple Event send attributed to this app. Without this (plus
+         NSAppleEventsUsageDescription in Info.plist) a hardened-runtime build is
+         denied automation and the hand-off silently fails. -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+  </dict>
+</plist>

--- a/app/package.json
+++ b/app/package.json
@@ -85,11 +85,27 @@
     "mac": {
       "category": "public.app-category.productivity",
       "icon": "build/icon.png",
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
       ],
       "extendInfo": {
+        "NSAppleEventsUsageDescription": "Memex needs permission to control Terminal so it can hand off to a Claude Code session in your project directory.",
         "CFBundleDocumentTypes": [
           {
             "CFBundleTypeRole": "Viewer",
@@ -105,7 +121,13 @@
     "win": {
       "icon": "build/icon.png",
       "target": [
-        "nsis"
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ]
     },
     "linux": {
@@ -115,6 +137,11 @@
         "AppImage",
         "deb"
       ]
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "arjunrajlaboratory",
+      "repo": "Memex"
     }
   }
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,9 +31,11 @@ signing and notarization, and still produces a build. That keeps forks and
 credential-less runs working — but an unsigned macOS build is quarantined by
 Gatekeeper on other people's machines, so real distribution needs the secrets.
 
-## macOS: one-time Apple setup
+## macOS: signing certificate
 
-You need the Apple Developer Program ($99/yr).
+You need the Apple Developer Program ($99/yr). Signing and notarization are two
+separate credentials: this section covers the certificate that signs the app, the
+next one covers the key that submits it to Apple's notary service. You need both.
 
 **1. Create the certificate.** In the Apple Developer portal → Certificates → `+`
 → **Developer ID Application** (not "Mac App Distribution" — that's for the App
@@ -51,13 +53,42 @@ like one.
 base64 -i DeveloperID.p12 | pbcopy
 ```
 
-**4. Create an app-specific password** for notarization at
-[appleid.apple.com](https://appleid.apple.com) → Sign-In and Security →
-App-Specific Passwords. (Apple's notary service will not accept your normal
-password.)
+## macOS: notarization credentials (App Store Connect API key)
 
-**5. Find your Team ID** — the 10-character code in the Apple Developer portal
-under Membership details.
+Notarization proves to Gatekeeper that Apple has scanned the build. It needs
+separate credentials from the signing certificate. This project uses an **App
+Store Connect API key**: it belongs to the team rather than one person's Apple
+ID, survives password rotations and 2FA changes, and can be revoked on its own.
+
+**4. Create the key.** [App Store Connect](https://appstoreconnect.apple.com) →
+**Users and Access** → **Integrations** tab → **App Store Connect API** →
+**Team Keys**.
+
+Use *Team Keys*, not *Individual Keys* — an individual key is bound to your
+personal account and defeats the point of using an API key at all.
+
+Click `+`, name it something like `notarize-ci`, and give it the **Developer**
+role. Developer is sufficient for notarization; Admin also works but grants far
+more than this needs.
+
+**5. Download the `.p8` — you only get one chance.** Apple lets you download the
+private key exactly once. If you lose it, the key must be revoked and replaced.
+Download it and keep a copy in your password manager before going further.
+
+**6. Note the two identifiers** from that same page:
+
+- **Key ID** — the 10-character string in the key's row.
+- **Issuer ID** — the UUID shown above the key list. It's per-team, not per-key,
+  and it's easy to miss because it sits outside the table.
+
+**7. Base64-encode the key** for the GitHub secret:
+
+```bash
+base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
+```
+
+Base64 rather than pasting the raw PEM: it survives any whitespace or
+line-ending mangling on the way into a secret.
 
 ### GitHub secrets to add
 
@@ -67,26 +98,39 @@ Repo → Settings → Secrets and variables → Actions → New repository secre
 | --- | --- |
 | `MAC_CSC_LINK` | base64 of the `.p12` from step 3 |
 | `MAC_CSC_KEY_PASSWORD` | the `.p12` export password from step 2 |
-| `APPLE_ID` | your Apple ID email |
-| `APPLE_APP_SPECIFIC_PASSWORD` | the app-specific password from step 4 |
-| `APPLE_TEAM_ID` | your 10-character Team ID |
+| `APPLE_API_KEY_P8` | base64 of the `.p8` from step 7 |
+| `APPLE_API_KEY_ID` | the 10-character Key ID from step 6 |
+| `APPLE_API_ISSUER` | the Issuer UUID from step 6 |
 
-**Alternative — App Store Connect API key.** More robust than an app-specific
-password (team-owned rather than tied to one person's Apple ID, and unaffected by
-password rotation). electron-builder reads `APPLE_API_KEY`, `APPLE_API_KEY_ID`,
-and `APPLE_API_ISSUER` instead of the three `APPLE_*` values above. Note that
-`APPLE_API_KEY` must be a **filesystem path to the `.p8` file**, not the key
-contents, so the workflow needs an extra step to materialize it:
+No `APPLE_TEAM_ID` is needed on this route — that variable only applies to the
+Apple ID / app-specific-password alternative.
 
-```yaml
-- name: Write App Store Connect key
-  run: |
-    mkdir -p ~/private_keys
-    echo "${{ secrets.APPLE_API_KEY_P8 }}" | base64 --decode > ~/private_keys/AuthKey.p8
-    echo "APPLE_API_KEY=$HOME/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
-```
+### Two implementation details worth knowing
 
-### Entitlements, and why the hand-off needs them
+**`APPLE_API_KEY` is a file path, not key material.** `notarytool` reads the key
+from disk, so the workflow decodes `APPLE_API_KEY_P8` into `$RUNNER_TEMP` and
+points `APPLE_API_KEY` at that file. Setting `APPLE_API_KEY` to the key contents
+fails with a confusing "file not found"-shaped error.
+
+**Do not also set `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD`.** electron-builder's
+documentation lists the API key as the first-choice route, but the implementation
+checks the Apple ID variables *first* — so if both are present, your API key is
+silently ignored. Pick one; this repo is set up for the API key.
+
+<details>
+<summary>Alternative: Apple ID + app-specific password</summary>
+
+Quicker to set up, but tied to an individual and breaks on password rotation.
+Create an app-specific password at [appleid.apple.com](https://appleid.apple.com)
+→ Sign-In and Security → App-Specific Passwords, find your 10-character Team ID
+under Membership details in the developer portal, then set `APPLE_ID`,
+`APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID` as secrets and swap those into
+the macOS job's `env:` block in place of the `APPLE_API_*` values (also removing
+the "Write App Store Connect API key" step).
+
+</details>
+
+## Entitlements, and why the hand-off needs them
 
 `app/build/entitlements.mac.plist` carries the usual Electron entitlements (JIT,
 unsigned executable memory, library validation) plus

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,165 @@
+# Releasing Memex Desktop
+
+How to produce signed, distributable builds of the desktop app (`app/`).
+
+Builds run in GitHub Actions (`.github/workflows/release.yml`) and publish to a
+**draft** GitHub Release. Because this repo is public, the release assets double as
+the update feed — no separate hosting or access token needed.
+
+```
+git tag app-v0.1.0
+git push origin app-v0.1.0     # → builds mac/win/linux, uploads to a draft release
+```
+
+Then review the draft release on GitHub and publish it by hand. To rehearse the
+pipeline without uploading anything, use the workflow's manual trigger
+("Run workflow") with `publish` left unchecked.
+
+App tags are prefixed `app-v` so desktop releases stay distinguishable from
+engine versioning (`VERSION`).
+
+## What each platform needs
+
+| Platform | Signing | Status |
+| --- | --- | --- |
+| macOS | Developer ID Application cert + notarization | needs the secrets below |
+| Windows | Azure Trusted Signing (or an EV cert) | **unsigned today** — SmartScreen warns |
+| Linux | none | works as-is |
+
+Missing macOS secrets are not fatal: electron-builder logs a warning, skips
+signing and notarization, and still produces a build. That keeps forks and
+credential-less runs working — but an unsigned macOS build is quarantined by
+Gatekeeper on other people's machines, so real distribution needs the secrets.
+
+## macOS: one-time Apple setup
+
+You need the Apple Developer Program ($99/yr).
+
+**1. Create the certificate.** In the Apple Developer portal → Certificates → `+`
+→ **Developer ID Application** (not "Mac App Distribution" — that's for the App
+Store). Follow the CSR flow, download the `.cer`, and double-click to install it
+into your login keychain.
+
+**2. Export it as a `.p12`.** In Keychain Access, find
+"Developer ID Application: <your name> (<team id>)", right-click → Export →
+`.p12`, and set a strong password. This file contains your private key — treat it
+like one.
+
+**3. Base64-encode it** for the GitHub secret:
+
+```bash
+base64 -i DeveloperID.p12 | pbcopy
+```
+
+**4. Create an app-specific password** for notarization at
+[appleid.apple.com](https://appleid.apple.com) → Sign-In and Security →
+App-Specific Passwords. (Apple's notary service will not accept your normal
+password.)
+
+**5. Find your Team ID** — the 10-character code in the Apple Developer portal
+under Membership details.
+
+### GitHub secrets to add
+
+Repo → Settings → Secrets and variables → Actions → New repository secret:
+
+| Secret | Value |
+| --- | --- |
+| `MAC_CSC_LINK` | base64 of the `.p12` from step 3 |
+| `MAC_CSC_KEY_PASSWORD` | the `.p12` export password from step 2 |
+| `APPLE_ID` | your Apple ID email |
+| `APPLE_APP_SPECIFIC_PASSWORD` | the app-specific password from step 4 |
+| `APPLE_TEAM_ID` | your 10-character Team ID |
+
+**Alternative — App Store Connect API key.** More robust than an app-specific
+password (team-owned rather than tied to one person's Apple ID, and unaffected by
+password rotation). electron-builder reads `APPLE_API_KEY`, `APPLE_API_KEY_ID`,
+and `APPLE_API_ISSUER` instead of the three `APPLE_*` values above. Note that
+`APPLE_API_KEY` must be a **filesystem path to the `.p8` file**, not the key
+contents, so the workflow needs an extra step to materialize it:
+
+```yaml
+- name: Write App Store Connect key
+  run: |
+    mkdir -p ~/private_keys
+    echo "${{ secrets.APPLE_API_KEY_P8 }}" | base64 --decode > ~/private_keys/AuthKey.p8
+    echo "APPLE_API_KEY=$HOME/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
+```
+
+### Entitlements, and why the hand-off needs them
+
+`app/build/entitlements.mac.plist` carries the usual Electron entitlements (JIT,
+unsigned executable memory, library validation) plus
+`com.apple.security.automation.apple-events`, paired with
+`NSAppleEventsUsageDescription` in `package.json`'s `mac.extendInfo`.
+
+That pair exists for the **Claude Code hand-off**: it drives Terminal.app through
+`osascript`, which macOS attributes to Memex as an Apple Event send. Under the
+hardened runtime, without the entitlement and the usage string, automation is
+denied and the hand-off silently fails. The first hand-off in a signed build
+triggers a one-time "Memex wants to control Terminal" prompt — expected, and the
+usage string is what that dialog shows.
+
+The app is **not** sandboxed (Developer ID direct distribution, not App Store),
+which is what lets it read arbitrary vault directories and spawn `python3` for
+vault creation. Sandboxing it would require an entitlement rethink.
+
+## Windows: signing when you're ready
+
+Since the 2023 CA/Browser rule change, OV and EV certificates must live on
+hardware tokens or an HSM, which makes plain cert files a non-starter in CI. The
+practical options:
+
+- **Azure Trusted Signing** (~$10/month, Microsoft-operated, no hardware token,
+  supported natively by electron-builder). Requires a verified organization or an
+  individual identity validation. Add to `package.json` under `build.win`:
+
+  ```json
+  "azureSignOptions": {
+    "publisherName": "<your verified name>",
+    "endpoint": "https://<region>.codesigning.azure.net",
+    "codeSigningAccountName": "<account>",
+    "certificateProfileName": "<profile>"
+  }
+  ```
+
+  then uncomment the `AZURE_*` env lines in the workflow and add those secrets.
+
+- **An EV certificate** from DigiCert / Sectigo / SSL.com. EV clears SmartScreen
+  immediately; OV has to accumulate reputation over time.
+
+Until then the Windows installer is unsigned and users see a SmartScreen
+"unrecognized app" warning — worth calling out in the release notes.
+
+## Auto-update (not wired up yet)
+
+The `build.publish` block already points at GitHub Releases, which is the feed
+format `electron-updater` expects (`latest-mac.yml` / `latest.yml` alongside the
+`zip` and `nsis` artifacts — this is why `zip` is a macOS target and not just
+`dmg`). Turning it on is a follow-up: add `electron-updater` and call
+`autoUpdater.checkForUpdatesAndNotify()` from the main process.
+
+Two constraints worth knowing before that work starts:
+
+- macOS auto-update only functions on **signed** builds — Squirrel.Mac silently
+  refuses unsigned or mismatched-identity updates. Signing is a prerequisite, not
+  a nice-to-have.
+- Because this repo is public, the updater needs no token. (A private repo would
+  have to embed one, which is why the usual workaround is a separate public
+  releases repo as the feed.)
+
+## Local builds
+
+```bash
+cd app
+npm run pack        # unpacked build in release/, no installer, no signing
+npm run dist:mac    # full macOS build; signs only if a Developer ID cert is in your keychain
+```
+
+To force an unsigned local build even with a certificate installed:
+
+```bash
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run dist:mac
+```
+
+`release/` is gitignored.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,21 +37,57 @@ You need the Apple Developer Program ($99/yr). Signing and notarization are two
 separate credentials: this section covers the certificate that signs the app, the
 next one covers the key that submits it to Apple's notary service. You need both.
 
-**1. Create the certificate.** In the Apple Developer portal → Certificates → `+`
-→ **Developer ID Application** (not "Mac App Distribution" — that's for the App
-Store). Follow the CSR flow, download the `.cer`, and double-click to install it
-into your login keychain.
+This produces two secrets — `MAC_CSC_LINK` (the certificate and its private key)
+and `MAC_CSC_KEY_PASSWORD` (the password protecting them).
 
-**2. Export it as a `.p12`.** In Keychain Access, find
-"Developer ID Application: <your name> (<team id>)", right-click → Export →
-`.p12`, and set a strong password. This file contains your private key — treat it
-like one.
+**1. Generate a certificate signing request (CSR).** Open **Keychain Access**
+(Applications → Utilities) → menu **Certificate Assistant** → **Request a
+Certificate From a Certificate Authority**. Enter your email and name, choose
+**Saved to disk**, and save the `.certSigningRequest` file. This also creates the
+private key in your keychain — the certificate is useless without it.
 
-**3. Base64-encode it** for the GitHub secret:
+**2. Create the certificate.** Apple Developer portal → **Certificates, IDs &
+Profiles** → Certificates → `+` → **Developer ID Application**.
+
+Not "Mac App Distribution" or "Apple Development" — those are App Store and
+local-development certificates and neither one lets you distribute a downloadable
+app. Creating a Developer ID certificate requires the **Account Holder** role
+(automatic if this is an individual account).
+
+Upload the CSR from step 1, then download the resulting `.cer`.
+
+**3. Install it.** Double-click the `.cer`. Confirm it landed:
+
+```bash
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+One line should come back. If nothing does, the certificate didn't import or its
+private key is missing — recheck step 1.
+
+**4. Export as `.p12`.** In Keychain Access, select the **My Certificates**
+category, find "Developer ID Application: &lt;your name&gt; (&lt;team id&gt;)", and
+confirm it has a disclosure triangle revealing a private key underneath. Right-click
+the certificate → **Export** → `.p12`, and set a strong password.
+
+Exporting from *My Certificates* is what bundles the private key. If you export
+from the *Certificates* category instead you get a key-less file, and signing
+fails later with an unhelpful error.
+
+**5. Base64-encode it** for the GitHub secret:
 
 ```bash
 base64 -i DeveloperID.p12 | pbcopy
 ```
+
+`pbcopy` prints nothing — it copies silently. To confirm it worked:
+
+```bash
+pbpaste | wc -c        # should be a few thousand bytes
+```
+
+The `.p12` and the `.p8` both contain private keys. Keep them in a password
+manager and don't commit them.
 
 ## macOS: notarization credentials (App Store Connect API key)
 
@@ -60,7 +96,7 @@ separate credentials from the signing certificate. This project uses an **App
 Store Connect API key**: it belongs to the team rather than one person's Apple
 ID, survives password rotations and 2FA changes, and can be revoked on its own.
 
-**4. Create the key.** [App Store Connect](https://appstoreconnect.apple.com) →
+**6. Create the key.** [App Store Connect](https://appstoreconnect.apple.com) →
 **Users and Access** → **Integrations** tab → **App Store Connect API** →
 **Team Keys**.
 
@@ -71,17 +107,17 @@ Click `+`, name it something like `notarize-ci`, and give it the **Developer**
 role. Developer is sufficient for notarization; Admin also works but grants far
 more than this needs.
 
-**5. Download the `.p8` — you only get one chance.** Apple lets you download the
+**7. Download the `.p8` — you only get one chance.** Apple lets you download the
 private key exactly once. If you lose it, the key must be revoked and replaced.
 Download it and keep a copy in your password manager before going further.
 
-**6. Note the two identifiers** from that same page:
+**8. Note the two identifiers** from that same page:
 
 - **Key ID** — the 10-character string in the key's row.
 - **Issuer ID** — the UUID shown above the key list. It's per-team, not per-key,
   and it's easy to miss because it sits outside the table.
 
-**7. Base64-encode the key** for the GitHub secret:
+**9. Base64-encode the key** for the GitHub secret:
 
 ```bash
 base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
@@ -96,11 +132,11 @@ Repo → Settings → Secrets and variables → Actions → New repository secre
 
 | Secret | Value |
 | --- | --- |
-| `MAC_CSC_LINK` | base64 of the `.p12` from step 3 |
-| `MAC_CSC_KEY_PASSWORD` | the `.p12` export password from step 2 |
-| `APPLE_API_KEY_P8` | base64 of the `.p8` from step 7 |
-| `APPLE_API_KEY_ID` | the 10-character Key ID from step 6 |
-| `APPLE_API_ISSUER` | the Issuer UUID from step 6 |
+| `MAC_CSC_LINK` | base64 of the `.p12` from step 5 |
+| `MAC_CSC_KEY_PASSWORD` | the `.p12` export password you set in step 4 |
+| `APPLE_API_KEY_P8` | base64 of the `.p8` from step 9 |
+| `APPLE_API_KEY_ID` | the 10-character Key ID from step 8 |
+| `APPLE_API_ISSUER` | the Issuer UUID from step 8 |
 
 No `APPLE_TEAM_ID` is needed on this route — that variable only applies to the
 Apple ID / app-specific-password alternative.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -40,11 +40,41 @@ next one covers the key that submits it to Apple's notary service. You need both
 This produces two secrets — `MAC_CSC_LINK` (the certificate and its private key)
 and `MAC_CSC_KEY_PASSWORD` (the password protecting them).
 
-**1. Generate a certificate signing request (CSR).** Open **Keychain Access**
-(Applications → Utilities) → menu **Certificate Assistant** → **Request a
-Certificate From a Certificate Authority**. Enter your email and name, choose
-**Saved to disk**, and save the `.certSigningRequest` file. This also creates the
-private key in your keychain — the certificate is useless without it.
+**1. Generate a certificate signing request (CSR).** For CI the certificate only
+ever needs to exist as a `.p12` file, so the whole thing can be done with
+`openssl` — no GUI, and every step is verifiable:
+
+```bash
+mkdir -p ~/memex-signing && chmod 700 ~/memex-signing && cd ~/memex-signing
+openssl req -new -newkey rsa:2048 -nodes \
+  -keyout DeveloperID.key \
+  -out DeveloperID.csr \
+  -subj "/emailAddress=you@example.com/CN=Your Name/C=US"
+chmod 600 DeveloperID.key
+openssl req -in DeveloperID.csr -noout -verify   # "verify OK"
+```
+
+Apple requires RSA 2048 for this CSR. Keep `DeveloperID.key` — the certificate
+Apple issues is useless without the matching private key.
+
+<details>
+<summary>GUI alternative via Keychain Access</summary>
+
+Worth knowing: on macOS 15+ **Keychain Access is no longer in Applications →
+Utilities** (Passwords.app took its slot) and Spotlight may not index it. It now
+lives at `/System/Library/CoreServices/Applications/Keychain Access.app`:
+
+```bash
+open "/System/Library/CoreServices/Applications/Keychain Access.app"
+```
+
+Then use the **Keychain Access** application menu (next to the Apple menu) →
+**Certificate Assistant** → **Request a Certificate From a Certificate
+Authority**. Enter your email and name, choose **Saved to disk**. This route puts
+the private key in your login keychain rather than a file, which is what you want
+if you also intend to sign builds locally.
+
+</details>
 
 **2. Create the certificate.** Apple Developer portal → **Certificates, IDs &
 Profiles** → Certificates → `+` → **Developer ID Application**.
@@ -54,27 +84,44 @@ local-development certificates and neither one lets you distribute a downloadabl
 app. Creating a Developer ID certificate requires the **Account Holder** role
 (automatic if this is an individual account).
 
-Upload the CSR from step 1, then download the resulting `.cer`.
+Upload `DeveloperID.csr`, then download the resulting `.cer` (it'll land in
+`~/Downloads` as something like `developerID_application.cer`).
 
-**3. Install it.** Double-click the `.cer`. Confirm it landed:
+**3. Build the `.p12`.** Combine Apple's certificate with the private key from
+step 1. Apple ships the `.cer` in DER form, so convert it first:
 
 ```bash
-security find-identity -v -p codesigning | grep "Developer ID Application"
+cd ~/memex-signing
+mv ~/Downloads/developerID_application.cer .        # adjust to the real filename
+openssl x509 -inform DER -in developerID_application.cer -out DeveloperID.pem
+openssl pkcs12 -export \
+  -inkey DeveloperID.key \
+  -in DeveloperID.pem \
+  -out DeveloperID.p12          # prompts for an export password — save it
 ```
 
-One line should come back. If nothing does, the certificate didn't import or its
-private key is missing — recheck step 1.
+Verify the bundle actually contains both halves:
 
-**4. Export as `.p12`.** In Keychain Access, select the **My Certificates**
-category, find "Developer ID Application: &lt;your name&gt; (&lt;team id&gt;)", and
-confirm it has a disclosure triangle revealing a private key underneath. Right-click
-the certificate → **Export** → `.p12`, and set a strong password.
+```bash
+openssl pkcs12 -in DeveloperID.p12 -nokeys -passin pass:YOUR_PASSWORD | grep subject
+openssl pkcs12 -in DeveloperID.p12 -nocerts -noout -passin pass:YOUR_PASSWORD && echo "private key present"
+```
 
-Exporting from *My Certificates* is what bundles the private key. If you export
-from the *Certificates* category instead you get a key-less file, and signing
-fails later with an unhelpful error.
+A `.p12` without the private key is the classic failure here — it imports fine in
+CI and then fails at signing time with an unhelpful error.
 
-**5. Base64-encode it** for the GitHub secret:
+<details>
+<summary>If you used the Keychain Access route instead</summary>
+
+Double-click the `.cer` to install it, confirm with
+`security find-identity -v -p codesigning | grep "Developer ID Application"`,
+then in Keychain Access select the **My Certificates** category, right-click the
+certificate → **Export** → `.p12`. Exporting from *My Certificates* is what
+bundles the private key; exporting from plain *Certificates* silently omits it.
+
+</details>
+
+**4. Base64-encode it** for the GitHub secret:
 
 ```bash
 base64 -i DeveloperID.p12 | pbcopy
@@ -86,8 +133,8 @@ base64 -i DeveloperID.p12 | pbcopy
 pbpaste | wc -c        # should be a few thousand bytes
 ```
 
-The `.p12` and the `.p8` both contain private keys. Keep them in a password
-manager and don't commit them.
+The `.p12`, the `.key`, and the `.p8` all contain private keys. Keep them in a
+password manager, and don't commit them.
 
 ## macOS: notarization credentials (App Store Connect API key)
 
@@ -96,7 +143,7 @@ separate credentials from the signing certificate. This project uses an **App
 Store Connect API key**: it belongs to the team rather than one person's Apple
 ID, survives password rotations and 2FA changes, and can be revoked on its own.
 
-**6. Create the key.** [App Store Connect](https://appstoreconnect.apple.com) →
+**1. Create the key.** [App Store Connect](https://appstoreconnect.apple.com) →
 **Users and Access** → **Integrations** tab → **App Store Connect API** →
 **Team Keys**.
 
@@ -107,17 +154,17 @@ Click `+`, name it something like `notarize-ci`, and give it the **Developer**
 role. Developer is sufficient for notarization; Admin also works but grants far
 more than this needs.
 
-**7. Download the `.p8` — you only get one chance.** Apple lets you download the
+**2. Download the `.p8` — you only get one chance.** Apple lets you download the
 private key exactly once. If you lose it, the key must be revoked and replaced.
 Download it and keep a copy in your password manager before going further.
 
-**8. Note the two identifiers** from that same page:
+**3. Note the two identifiers** from that same page:
 
 - **Key ID** — the 10-character string in the key's row.
 - **Issuer ID** — the UUID shown above the key list. It's per-team, not per-key,
   and it's easy to miss because it sits outside the table.
 
-**9. Base64-encode the key** for the GitHub secret:
+**4. Base64-encode the key** for the GitHub secret:
 
 ```bash
 base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
@@ -132,11 +179,11 @@ Repo → Settings → Secrets and variables → Actions → New repository secre
 
 | Secret | Value |
 | --- | --- |
-| `MAC_CSC_LINK` | base64 of the `.p12` from step 5 |
-| `MAC_CSC_KEY_PASSWORD` | the `.p12` export password you set in step 4 |
-| `APPLE_API_KEY_P8` | base64 of the `.p8` from step 9 |
-| `APPLE_API_KEY_ID` | the 10-character Key ID from step 8 |
-| `APPLE_API_ISSUER` | the Issuer UUID from step 8 |
+| `MAC_CSC_LINK` | base64 of `DeveloperID.p12` (certificate section, step 4) |
+| `MAC_CSC_KEY_PASSWORD` | the `.p12` export password you chose when running `openssl pkcs12 -export` |
+| `APPLE_API_KEY_P8` | base64 of the `.p8` (API key section, step 4) |
+| `APPLE_API_KEY_ID` | the 10-character Key ID (API key section, step 3) |
+| `APPLE_API_ISSUER` | the Issuer UUID (API key section, step 3) |
 
 No `APPLE_TEAM_ID` is needed on this route — that variable only applies to the
 Apple ID / app-specific-password alternative.


### PR DESCRIPTION
Adds the packaging and distribution scaffold so Memex Desktop can be signed and shipped. Config and CI only — no app behavior changes.

## What's here

- **`app/build/entitlements.mac.plist`** — electron-builder's standard Electron entitlements (JIT, unsigned executable memory, library validation) plus `com.apple.security.automation.apple-events`. That last one is load-bearing for the **Claude Code hand-off**: it drives Terminal through `osascript`, which macOS attributes to Memex as an Apple Event send, and a hardened-runtime build is denied automation without it. Paired with `NSAppleEventsUsageDescription` in `mac.extendInfo` (the string shown in the one-time "Memex wants to control Terminal" prompt).
- **`app/package.json`** — `hardenedRuntime`, entitlements, arm64 + x64 targets for macOS and Windows, and a `publish` block pointing at GitHub Releases. Because this repo is public, releases double as the `electron-updater` feed with no embedded token.
- **`.github/workflows/release.yml`** — tag-triggered (`app-v*`) mac/win/linux builds that publish to a **draft** release, plus a manual trigger for rehearsing the pipeline without uploading.
- **`docs/RELEASING.md`** — Apple certificate + notarization setup, the exact repo secrets to add, Windows signing options, and auto-update prerequisites.

## Notes on the workflow

It calls the existing `dist:*` npm scripts rather than `npx electron-builder` directly, so `tsc` always runs before packaging (calling electron-builder directly would package a stale `dist/`). Unit tests run only on Linux — they're plain Node, and the `test/*.test.cjs` glob needs a POSIX shell to expand.

Notarization in electron-builder 26 is driven **only** by environment variables (`APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID`, or the App Store Connect API key trio) — there is no `notarize.teamId` config equivalent. When credentials are absent it logs a warning and skips rather than failing, so forks and secret-less runs still exercise the build.

## Verification

- Unsigned `npm run pack` succeeds and degrades gracefully (`skipped macOS application code signing`).
- Both `extendInfo` keys land in the built `Info.plist`, and the engine resources bundle correctly.
- `codesign --options runtime --entitlements build/entitlements.mac.plist` accepts the file and embeds all four entitlements.
- Workflow YAML parses; all three jobs wired as intended.

## Still needed (requires your accounts)

1. Apple: Developer ID Application cert → export `.p12` → base64 → `MAC_CSC_LINK` + `MAC_CSC_KEY_PASSWORD`; app-specific password → `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`.
2. Windows is **unsigned** for now (SmartScreen will warn). `docs/RELEASING.md` has the Azure Trusted Signing config to drop in when ready.
3. Auto-update isn't wired yet — the feed format is in place, but it needs `electron-updater` plus a main-process check. macOS auto-update requires signed builds, so signing lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)