### PR TITLE
desktop: fix the three release-pipeline failures

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,11 +2,15 @@
   "name": "memex-desktop",
   "version": "0.1.0",
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
-  "author": "Memex",
+  "author": {
+    "name": "Arjun Raj",
+    "email": "arjunrajlab@gmail.com"
+  },
   "license": "MIT",
+  "homepage": "https://github.com/arjunrajlaboratory/Memex",
   "main": "dist/main/main.js",
   "scripts": {
-    "assets": "mkdir -p dist/renderer && cp src/renderer/index.html src/renderer/styles.css dist/renderer/",
+    "assets": "node scripts/copy-assets.js",
     "build": "tsc && npm run assets",
     "typecheck": "tsc --noEmit",
     "test": "npm run build && node --test test/*.test.cjs",

--- a/app/scripts/copy-assets.js
+++ b/app/scripts/copy-assets.js
@@ -1,0 +1,13 @@
+// Copies the renderer's static assets into dist/. Replaces `mkdir -p && cp`,
+// which is not valid on Windows (cmd's mkdir has no -p, and there is no cp), so
+// the packaging build failed there.
+const fs = require('fs');
+const path = require('path');
+
+const src = path.join(__dirname, '..', 'src', 'renderer');
+const dest = path.join(__dirname, '..', 'dist', 'renderer');
+
+fs.mkdirSync(dest, { recursive: true });
+for (const file of ['index.html', 'styles.css']) {
+  fs.copyFileSync(path.join(src, file), path.join(dest, file));
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -94,10 +94,27 @@ step 1. Apple ships the `.cer` in DER form, so convert it first:
 cd ~/memex-signing
 mv ~/Downloads/developerID_application.cer .        # adjust to the real filename
 openssl x509 -inform DER -in developerID_application.cer -out DeveloperID.pem
-openssl pkcs12 -export \
+openssl pkcs12 -export -legacy \
   -inkey DeveloperID.key \
   -in DeveloperID.pem \
   -out DeveloperID.p12          # prompts for an export password — save it
+```
+
+**`-legacy` is required, not optional.** OpenSSL 3 defaults to PBES2 / AES-256-CBC
+with a SHA-256 MAC, which Apple's `security` tool cannot read. Without the flag
+the CI build fails at certificate import with:
+
+```
+security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
+```
+
+The password is fine — it's the encryption scheme. `-legacy` emits the
+SHA1/3DES form macOS expects. You can confirm before pushing the secret:
+
+```bash
+security create-keychain -p testpw /tmp/t.keychain
+security import DeveloperID.p12 -k /tmp/t.keychain -P "$(cat p12-password.txt)" -T /usr/bin/codesign
+security delete-keychain /tmp/t.keychain
 ```
 
 Verify the bundle actually contains both halves:


### PR DESCRIPTION
The first real run of the release workflow failed on all three platforms, each for a different reason. Run: https://github.com/arjunrajlaboratory/Memex/actions/runs/30176543401

## Windows — latent cross-platform bug

```
> mkdir -p dist/renderer && cp src/renderer/index.html src/renderer/styles.css dist/renderer/
The syntax of the command is incorrect.
```

The `assets` npm script was Unix-only (`mkdir -p` has no Windows equivalent, and there's no `cp`). This wasn't introduced by the workflow — the build had simply never been run on Windows before. Replaced with `scripts/copy-assets.js`: plain Node, no new dependency.

## Linux — missing package metadata

```
⨯ Please specify project homepage
```

electron-builder's `deb` target needs it. Added `homepage`, and converted `author` to an object with an email since deb also requires a maintainer address. Used the same address as the repo's public commit history, so nothing new is disclosed.

## macOS — misleading certificate error

```
⨯ /usr/bin/security process failed 1
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

The password was correct. OpenSSL 3 defaults to PBES2 / AES-256-CBC with a SHA-256 MAC for PKCS#12, and Apple's `security` tool can't read that — it needs the legacy SHA1/3DES form. Reproduced locally, fixed by rebuilding the `.p12` with `openssl pkcs12 -export -legacy`, and reissued the `MAC_CSC_LINK` secret from it. `docs/RELEASING.md` now documents the flag as required, with the error it produces when missing and a local verification recipe.

## Verification

- `security import` of the new `.p12` into a throwaway keychain succeeds (it failed before the fix — the CI failure reproduces locally).
- `security verify-cert -p codeSign` on the certificate: verification successful.
- `npm run build` and `npm test` pass with the new assets script; `dist/renderer/` gets both files.

Signing itself is still unproven end-to-end — that needs a CI run on a macOS runner, which is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)