### PR TITLE
desktop: notarize the DMG artifacts + full release playbook

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
   "build": {
     "appId": "app.memex.desktop",
     "productName": "Memex",
+    "artifactBuildCompleted": "./scripts/notarize-dmg.js",
     "directories": {
       "buildResources": "build",
       "output": "release"

--- a/app/scripts/notarize-dmg.js
+++ b/app/scripts/notarize-dmg.js
@@ -1,0 +1,44 @@
+// electron-builder notarizes the .app and then builds the DMG around it, so the
+// disk image itself ships un-notarized: Gatekeeper rejects it with "no usable
+// signature" even though the app inside is signed, notarized and stapled. Users
+// hit that when they open the downloaded DMG. This hook submits each DMG to the
+// notary service and staples the ticket to it.
+//
+// It runs on `artifactBuildCompleted` rather than `afterAllArtifactBuild`
+// because that fires before the artifact's hash reaches latest-mac.yml.
+// Stapling rewrites the DMG, so the hash electron-builder already computed goes
+// stale — `event.updateInfo` is patched below to keep the update manifest
+// honest. (Verified: without the patch, latest-mac.yml records the pre-staple
+// size and sha512.)
+const { execFileSync } = require('child_process');
+const crypto = require('crypto');
+const path = require('path');
+const fs = require('fs');
+
+exports.default = async function notarizeDmg(event) {
+  if (!event.file || !event.file.endsWith('.dmg')) return;
+
+  const { APPLE_API_KEY, APPLE_API_KEY_ID, APPLE_API_ISSUER } = process.env;
+  if (!APPLE_API_KEY || !APPLE_API_KEY_ID || !APPLE_API_ISSUER) {
+    console.log('  • skipped DMG notarization  reason=App Store Connect API key env vars not set');
+    return;
+  }
+
+  const name = path.basename(event.file);
+  console.log(`  • notarizing DMG  file=${name}`);
+  execFileSync('xcrun', [
+    'notarytool', 'submit', event.file,
+    '--key', APPLE_API_KEY,
+    '--key-id', APPLE_API_KEY_ID,
+    '--issuer', APPLE_API_ISSUER,
+    '--wait',
+  ], { stdio: 'inherit' });
+  execFileSync('xcrun', ['stapler', 'staple', event.file], { stdio: 'inherit' });
+
+  if (event.updateInfo) {
+    const contents = fs.readFileSync(event.file);
+    event.updateInfo.sha512 = crypto.createHash('sha512').update(contents).digest('base64');
+    event.updateInfo.size = contents.length;
+  }
+  console.log(`  • DMG notarized and stapled  file=${name}`);
+};

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -324,6 +324,85 @@ Two constraints worth knowing before that work starts:
   have to embed one, which is why the usual workaround is a separate public
   releases repo as the feed.)
 
+## Verifying a release before you publish it
+
+CI logs are not proof. electron-builder *skips* signing with a warning rather
+than failing, so a green run can still produce an unsigned app. Check the log for
+the real evidence:
+
+```
+• signing   identityName=Developer ID Application: CytoPixel Software LLC (632L8D99KB)
+• notarization successful
+• DMG notarized and stapled
+```
+
+Then test an actual downloaded artifact on a Mac — this is the only check that
+reflects what a user experiences:
+
+```bash
+# grab the DMG from the draft release (drafts need the asset API, not `gh release download`)
+ID=$(gh api repos/arjunrajlaboratory/Memex/releases \
+      --jq '.[] | select(.draft==true) | .assets[] | select(.name=="Memex-<version>-arm64.dmg") | .id')
+gh api "repos/arjunrajlaboratory/Memex/releases/assets/$ID" \
+      -H "Accept: application/octet-stream" > /tmp/Memex.dmg
+
+spctl -a -t open --context context:primary-signature -vv /tmp/Memex.dmg   # expect: accepted
+xcrun stapler validate /tmp/Memex.dmg                                     # expect: worked
+
+hdiutil attach /tmp/Memex.dmg -nobrowse -mountpoint /tmp/m
+spctl -a -vvv /tmp/m/Memex.app        # expect: accepted, source=Notarized Developer ID
+xcrun stapler validate /tmp/m/Memex.app
+codesign -dv --verbose=2 /tmp/m/Memex.app   # expect flags=0x10000(runtime), TeamIdentifier
+hdiutil detach /tmp/m
+```
+
+`flags=0x10000(runtime)` confirms the hardened runtime, which is what makes the
+entitlements meaningful.
+
+## Release naming: the git tag and the release tag differ
+
+Pushing `app-v0.1.0` produces a GitHub Release tagged **`v0.1.0`**. electron-builder
+names the release from `package.json`'s `version` and ignores the tag that
+triggered the build. That's what `electron-updater` expects, so leave it alone —
+just don't be surprised that the two differ, and remember to bump
+`app/package.json` `version` before tagging a new release. Tagging without
+bumping the version would try to reuse the existing release.
+
+## Troubleshooting
+
+**`security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)`**
+The password is almost certainly fine. OpenSSL 3 writes PKCS#12 with
+PBES2/AES-256-CBC, which Apple's `security` cannot read. Rebuild the `.p12` with
+`openssl pkcs12 -export -legacy` and update `MAC_CSC_LINK`.
+
+**`skipped macOS application code signing`**
+`CSC_LINK` / `CSC_KEY_PASSWORD` are missing or unreadable. This is a *warning* —
+the build still succeeds and silently produces an unsigned app.
+
+**`skipped macOS notarization`**
+The `APPLE_API_*` variables are absent. Also note that electron-builder checks
+`APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD` *first*: if those are set, your API key
+is ignored regardless of what the docs imply.
+
+**`⨯ Please specify project homepage`**
+The Linux `deb` target needs `homepage` and an `author` with an email in
+`app/package.json`.
+
+**`The syntax of the command is incorrect.` on Windows**
+A build script is using Unix shell syntax. `mkdir -p` and `cp` don't exist in
+cmd/pwsh — this is why asset copying goes through `scripts/copy-assets.js`
+instead of inline shell. Keep npm scripts cross-platform or Windows packaging
+breaks.
+
+**A notarization failure that reads like bad credentials**
+Check that the certificate and the API key belong to the *same* Apple team. A
+cross-team mismatch surfaces as an authentication error that never mentions
+teams.
+
+**How long it should take.** A failing run dies in about a minute. A real signed
+release takes roughly 7–8 minutes, since notarization adds ~2.5 minutes per
+architecture and the DMGs are notarized separately on top of that.
+
 ## Local builds
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -230,6 +230,38 @@ the "Write App Store Connect API key" step).
 
 </details>
 
+## DMG notarization
+
+electron-builder notarizes the `.app` and *then* builds the DMG around it, so the
+disk image itself ships un-notarized. The app inside is fine — it's signed,
+notarized and stapled, and Gatekeeper accepts it once installed — but the DMG
+wrapper gets rejected:
+
+```
+$ spctl -a -t open --context context:primary-signature Memex-0.1.0-arm64.dmg
+rejected  (source=no usable signature)
+```
+
+Users hit that when they open the downloaded disk image. `app/scripts/notarize-dmg.js`
+closes the gap: it submits each DMG to the notary service and staples the ticket.
+
+Two non-obvious details are baked into that script:
+
+- **It runs on `artifactBuildCompleted`, not `afterAllArtifactBuild`.** Only the
+  former fires before the artifact's hash is recorded for `latest-mac.yml`.
+- **It re-hashes the DMG afterward.** Stapling rewrites the file, so the hash
+  electron-builder computed goes stale; the script patches `event.updateInfo` so
+  the update manifest matches the shipped bytes. Without this, `latest-mac.yml`
+  records the pre-staple size and sha512.
+
+Do **not** set `dmg.sign: true` to solve this. electron-builder's own schema
+warns that signing the DMG "is not required and will lead to unwanted errors in
+combination with notarization requirements."
+
+Known cosmetic gap: the `.dmg.blockmap` is generated before stapling, so it
+describes the pre-staple file. Nothing reads it on macOS — `electron-updater`
+updates from the `.zip` — but it is technically stale.
+
 ## Entitlements, and why the hand-off needs them
 
 `app/build/entitlements.mac.plist` carries the usual Electron entitlements (JIT,


### PR DESCRIPTION
The published DMGs are rejected by Gatekeeper even though the app inside is fine:

```
$ spctl -a -t open --context context:primary-signature Memex-0.1.0-arm64.dmg
rejected  (source=no usable signature)
$ xcrun stapler validate Memex-0.1.0-arm64.dmg
does not have a ticket stapled to it
```

electron-builder notarizes the `.app` and *then* builds the DMG around it, so the disk image is never submitted. Users hit a warning when opening the download. (The app itself verified good: `accepted / source=Notarized Developer ID`, ticket stapled, hardened runtime on.)

Adds `scripts/notarize-dmg.js` to submit each DMG to notarytool and staple the ticket.

## Two details established by experiment, not assumption

**The hook must be `artifactBuildCompleted`, not `afterAllArtifactBuild`.** I probed both by mutating the DMG inside the hook and comparing `latest-mac.yml` against the file on disk:

| hook | manifest size | actual size | |
|---|---|---|---|
| `afterAllArtifactBuild` | 205380366 | 205384462 | stale |
| `artifactBuildCompleted`, no re-hash | 205380302 | 205384398 | stale |
| `artifactBuildCompleted` + re-hash | 205384560 | 205384560 | correct |

`emitArtifactBuildCompleted` awaits the hook before `emitArtifactCreated` (which feeds the manifest), but the hash is computed during DMG creation and carried on the event — so the hook must patch it.

**Hence the re-hash.** Stapling rewrites the DMG, so the script updates `event.updateInfo.sha512`/`.size`. Without it the update manifest advertises pre-staple bytes.

Also recorded: **do not** set `dmg.sign: true` — electron-builder's schema warns it "will lead to unwanted errors in combination with notarization requirements."

## Release playbook (second commit)

`docs/RELEASING.md` now captures everything this pipeline cost to get right:

- **How to verify a release for real** — `spctl` / `stapler validate` / `codesign` against a *downloaded* artifact, and why a green CI run isn't proof (signing skips are warnings, not failures).
- **Tag naming** — pushing `app-v0.1.0` yields a release tagged `v0.1.0`, because electron-builder names releases from `package.json` version. Bump the version before tagging.
- **Troubleshooting** for every failure actually encountered: the OpenSSL 3 PKCS#12 import error, silent signing/notarization skips, the `deb` homepage requirement, the Windows shell-syntax failure, and cross-team credential mismatch.
- **Realistic timings**, so a 7-minute run doesn't look hung.

## Verification

- Hook resolves and runs; with no credentials it logs `skipped DMG notarization` and the build still succeeds, so forks and dry runs are unaffected.
- With the hook wired in, an unsigned local build leaves `latest-mac.yml` consistent with the built DMG.
- End-to-end proof needs a credentialed CI run — re-cutting the release and re-verifying the downloaded DMG is the next step.

Known cosmetic gap, documented: `.dmg.blockmap` is generated pre-staple. Nothing reads it on macOS — `electron-updater` updates from the `.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)