### PR TITLE
desktop: wire up auto-update (0.1.1)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.211",
+        "electron-updater": "^6.8.9",
         "gray-matter": "^4.0.3",
         "marked": "^12.0.2",
         "zod": "^4.0.0"
@@ -1658,7 +1659,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2366,6 +2366,62 @@
         "mime": "^2.5.2"
       }
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/electron-updater/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -2877,7 +2933,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -3099,7 +3154,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gray-matter": {
@@ -3491,7 +3545,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -3523,7 +3576,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -3531,6 +3583,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -4457,7 +4522,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4889,6 +4953,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5064,7 +5134,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
   "author": {
     "name": "Arjun Raj",
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.211",
+    "electron-updater": "^6.8.9",
     "gray-matter": "^4.0.3",
     "marked": "^12.0.2",
     "zod": "^4.0.0"

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, protocol } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron';
+import electronUpdater from 'electron-updater';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -524,6 +525,25 @@ async function launchClaudeCode(dirPath: string, vault: string): Promise<{ ok: b
   return { ok: true, message: `Opening a terminal in ${full} to run Claude Code. Tell the user a terminal window is opening; if the \`claude\` command isn't found there, the Claude Code CLI needs to be installed.` };
 }
 
+// ---------- auto-update ----------
+// Updates come from the `latest-*.yml` feed the release workflow publishes
+// alongside the installers on GitHub Releases. The update is downloaded in the
+// background and applied when the app next quits.
+function initAutoUpdater(): void {
+  // Dev builds have no feed to read: electron-updater throws looking for
+  // dev-app-update.yml. Only packaged apps can update.
+  if (!app.isPackaged) return;
+  const { autoUpdater } = electronUpdater;
+  // A failed update check must stay invisible — it is not something the user
+  // asked for or can act on. An unhandled 'error' event would otherwise be
+  // thrown. Linux .deb installs land here too: electron-updater only supports
+  // AppImage on Linux.
+  autoUpdater.on('error', (err: Error) => {
+    console.error('auto-update check failed:', err?.message || err);
+  });
+  autoUpdater.checkForUpdatesAndNotify().catch(() => {});
+}
+
 async function startSession(vault: string): Promise<void> {
   if (session) { try { await session.stop(); } catch (_) {} session = null; }
   let nextSession: AgentSession;
@@ -930,6 +950,7 @@ if (!gotLock) {
     });
     registerIpc();
     createWindow();
+    initAutoUpdater();
     handleIconDrop(argvFiles(process.argv));
     app.on('activate', () => { if (BrowserWindow.getAllWindows().length === 0) createWindow(); });
   });

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -323,22 +323,39 @@ practical options:
 Until then the Windows installer is unsigned and users see a SmartScreen
 "unrecognized app" warning — worth calling out in the release notes.
 
-## Auto-update (not wired up yet)
+## Auto-update
 
-The `build.publish` block already points at GitHub Releases, which is the feed
-format `electron-updater` expects (`latest-mac.yml` / `latest.yml` alongside the
-`zip` and `nsis` artifacts — this is why `zip` is a macOS target and not just
-`dmg`). Turning it on is a follow-up: add `electron-updater` and call
-`autoUpdater.checkForUpdatesAndNotify()` from the main process.
+Wired up as of 0.1.1. `electron-updater` reads the `latest-*.yml` feed published
+alongside the installers, downloads a newer version in the background, and
+applies it when the app next quits. `initAutoUpdater()` in `src/main/main.ts` is
+the whole of it.
 
-Two constraints worth knowing before that work starts:
+Behaviour worth knowing:
 
-- macOS auto-update only functions on **signed** builds — Squirrel.Mac silently
-  refuses unsigned or mismatched-identity updates. Signing is a prerequisite, not
-  a nice-to-have.
-- Because this repo is public, the updater needs no token. (A private repo would
-  have to embed one, which is why the usual workaround is a separate public
-  releases repo as the feed.)
+- **Packaged builds only.** Dev builds return early — electron-updater looks for
+  a `dev-app-update.yml` that doesn't exist and throws.
+- **Failures are silent by design.** A failed check is not something the user
+  asked for or can act on, so the error handler logs and stops. That handler is
+  also load-bearing: an unhandled `error` event from the updater would throw.
+- **Checks once, at startup.** Fine for an app that gets restarted; if Memex
+  turns out to be something people leave open for days, add a periodic check.
+- **macOS updates come from the `.zip`, not the `.dmg`** — Squirrel.Mac installs
+  from a zip, which is why `zip` is a macOS target.
+- **Signing is a hard prerequisite on macOS.** Squirrel.Mac silently refuses
+  updates that aren't signed with the same identity, so an unsigned build simply
+  never updates rather than failing loudly.
+- **Linux: AppImage only.** `.deb` installs are not supported by
+  electron-updater; those errors land in the handler above and are ignored.
+  Debian users update through their package manager.
+- **Windows works but is unsigned**, so the downloaded updater triggers the same
+  SmartScreen warning as the initial install until Windows signing is set up.
+- **No token is embedded.** The repo is public, so the updater reads the feed
+  anonymously. A private repo would have to ship a credential in the app, which
+  is why the usual workaround there is a separate public releases repo.
+
+A release can only update users who already have an updater-capable build:
+0.1.0 shipped without one, so those installs must be replaced by hand. Every
+release from 0.1.1 onward can carry users forward.
 
 ## Verifying a release before you publish it
 


### PR DESCRIPTION
Installed builds couldn't upgrade themselves — shipping 0.2.0 would have stranded every 0.1.0 user on it. Adds `electron-updater`.

Most of this was already built: the release workflow publishes the `latest-*.yml` feed, the macOS `.zip` targets exist because Squirrel.Mac installs from a zip rather than a DMG, and the manifest hashes (kept correct through DMG stapling) are what updates get verified against. What was missing was the dependency and ~10 lines in the main process.

## Behaviour, and why

`initAutoUpdater()` downloads in the background and applies on quit.

- **Packaged builds only.** Dev returns early; electron-updater throws looking for a `dev-app-update.yml` that doesn't exist.
- **Failures are silent.** A failed update check isn't something the user asked for or can act on, so it logs and stops. The handler is also load-bearing — an unhandled `error` event from the updater would throw. Linux `.deb` installs land there too, since electron-updater supports only AppImage on Linux.
- **Checks once at startup.** Suits an app that gets restarted. If Memex turns out to be something people leave open for days, a periodic check is the obvious follow-up.

Windows updates work but remain unsigned, so they carry the same SmartScreen warning as the initial install — left as-is per the decision to defer Windows signing.

## Version

Bumped to **0.1.1**. electron-builder names releases from `package.json` version, and `v0.1.0` is already published, so tagging without a bump would collide.

Worth stating plainly: **0.1.0 installs have no updater and can't be carried forward** — anyone already on it has to re-download once. 0.1.1 onward updates cleanly.

## Verification

Build and tests pass, and the app starts cleanly with no updater errors in dev (confirming the `isPackaged` guard). End-to-end auto-update can only really be proven with two published releases — 0.1.1 is the first half of that; the next release is what actually exercises the upgrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)