### PR TITLE
desktop: fix 'spawn ENOTDIR' starting the agent in packaged builds (0.1.2)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
   "author": {
     "name": "Arjun Raj",

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -62,6 +62,7 @@ export class AgentSession {
   private onEvent: (evt: AgentEvent) => void;
   private requestPermission: (request: AgentPermissionRequest) => Promise<boolean>;
   private openInClaudeCode: (dirPath: string) => Promise<{ ok: boolean; message: string }>;
+  private claudeExecutable: string | undefined;
   private queue = new MessageQueue();
   private query: Query | null = null;
   running = false;
@@ -72,11 +73,15 @@ export class AgentSession {
     onEvent,
     requestPermission,
     openInClaudeCode,
+    claudeExecutable,
   }: {
     cwd: string;
     onEvent: (evt: AgentEvent) => void;
     requestPermission?: (request: AgentPermissionRequest) => Promise<boolean>;
     openInClaudeCode?: (dirPath: string) => Promise<{ ok: boolean; message: string }>;
+    // Absolute path to the bundled `claude` binary. The host supplies this in
+    // packaged builds, where the SDK's own resolution points into app.asar.
+    claudeExecutable?: string;
   }) {
     this.cwd = cwd;
     this.onEvent = onEvent || (() => {});
@@ -84,6 +89,7 @@ export class AgentSession {
     this.requestPermission = requestPermission || (async () => false);
     // Fail closed if a host does not supply a launcher.
     this.openInClaudeCode = openInClaudeCode || (async () => ({ ok: false, message: 'Claude Code hand-off is not available in this host.' }));
+    this.claudeExecutable = claudeExecutable;
   }
 
   async start(): Promise<void> {
@@ -126,6 +132,7 @@ export class AgentSession {
       prompt: this.queue,
       options: {
         cwd: this.cwd,
+        ...(this.claudeExecutable ? { pathToClaudeCodeExecutable: this.claudeExecutable } : {}),
         settingSources: ['user', 'project'],
         systemPrompt: { type: 'preset', preset: 'claude_code', append: APPEND_PROMPT },
         permissionMode: 'acceptEdits',

--- a/app/src/main/claude-binary.ts
+++ b/app/src/main/claude-binary.ts
@@ -1,0 +1,13 @@
+import * as path from 'path';
+
+// The agent SDK ships its `claude` CLI as a platform-specific sibling package
+// and resolves it relative to its own module path. Inside a packaged app that
+// resolution runs through app.asar — a file, not a directory — so spawning it
+// fails with ENOTDIR. Electron redirects file *reads* into app.asar.unpacked,
+// but not the executable handed to child_process.spawn, so the binary being
+// unpacked is not enough: the SDK has to be pointed at the unpacked copy.
+export function unpackedClaudeBinaryPath(resourcesPath: string, platform: string, arch: string): string {
+  const pkg = `claude-agent-sdk-${platform}-${arch}`;
+  const binary = platform === 'win32' ? 'claude.exe' : 'claude';
+  return path.join(resourcesPath, 'app.asar.unpacked', 'node_modules', '@anthropic-ai', pkg, binary);
+}

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -20,6 +20,7 @@ import { VaultTransitionGate } from './vault-transition';
 import { classifyVaultChange } from './watch-policy';
 import { buildWikiIndex } from './wiki-index';
 import { SerialQueue } from './serial-queue';
+import { unpackedClaudeBinaryPath } from './claude-binary';
 
 const fsp = fs.promises;
 // Development runs inside the engine checkout; packaged builds carry the exact
@@ -544,6 +545,18 @@ function initAutoUpdater(): void {
   autoUpdater.checkForUpdatesAndNotify().catch(() => {});
 }
 
+// Returns undefined in dev, where the SDK resolves its own binary correctly.
+// See claude-binary.ts for why packaged builds need this.
+function bundledClaudeExecutable(): string | undefined {
+  if (!app.isPackaged) return undefined;
+  const unpacked = unpackedClaudeBinaryPath(process.resourcesPath, process.platform, process.arch);
+  if (fs.existsSync(unpacked)) return unpacked;
+  // Fall through to the SDK's own resolution rather than forcing a bad path:
+  // its error message names the platform it looked for, which is more useful.
+  console.error('bundled claude binary not found at', unpacked);
+  return undefined;
+}
+
 async function startSession(vault: string): Promise<void> {
   if (session) { try { await session.stop(); } catch (_) {} session = null; }
   let nextSession: AgentSession;
@@ -570,6 +583,7 @@ async function startSession(vault: string): Promise<void> {
     onEvent: (evt: AgentEvent) => { chain = chain.then(() => handleEvent(evt)).catch(() => {}); },
     requestPermission: (request) => requestAgentPermission(vault, nextSession, request),
     openInClaudeCode: (dirPath: string) => launchClaudeCode(dirPath, vault),
+    claudeExecutable: bundledClaudeExecutable(),
   });
   session = nextSession;
   try {

--- a/app/test/claude-binary.test.cjs
+++ b/app/test/claude-binary.test.cjs
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { unpackedClaudeBinaryPath } = require('../dist/main/claude-binary.js');
+
+// Regression: 0.1.1 shipped pointing at the in-asar path and every packaged
+// session died with "spawn ENOTDIR". The path must land in app.asar.unpacked.
+test('resolves the unpacked binary, never a path through app.asar', () => {
+  const p = unpackedClaudeBinaryPath('/Apps/Memex.app/Contents/Resources', 'darwin', 'arm64');
+  assert.equal(
+    p,
+    '/Apps/Memex.app/Contents/Resources/app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude',
+  );
+  assert.ok(!/app\.asar\//.test(p.replace('app.asar.unpacked', '')), 'must not traverse app.asar');
+});
+
+test('picks the platform-specific package and executable name', () => {
+  assert.match(
+    unpackedClaudeBinaryPath('/r', 'darwin', 'x64'),
+    /@anthropic-ai\/claude-agent-sdk-darwin-x64\/claude$/,
+  );
+  assert.match(
+    unpackedClaudeBinaryPath('/r', 'linux', 'x64'),
+    /@anthropic-ai\/claude-agent-sdk-linux-x64\/claude$/,
+  );
+  // Windows needs the .exe suffix or spawn cannot find it.
+  assert.match(
+    unpackedClaudeBinaryPath('/r', 'win32', 'x64'),
+    /@anthropic-ai\/claude-agent-sdk-win32-x64\/claude\.exe$/,
+  );
+});

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -439,6 +439,15 @@ Ignore it. That tool expects an `.app` bundle; its verdict on a disk image is
 meaningless. Mount the DMG and run it against the `.app` inside, where
 "App passed all pre-distribution checks" is the answer you want.
 
+**`Agent session failed to start: spawn ENOTDIR` in a packaged build (works in dev)**
+The agent SDK resolves its bundled `claude` binary relative to its own module
+path, which in a packaged app runs through `app.asar` — a file, not a directory.
+Electron redirects file *reads* into `app.asar.unpacked` but not the executable
+handed to `spawn`, so electron-builder unpacking the binary is not sufficient on
+its own. `src/main/claude-binary.ts` computes the unpacked path and the host
+passes it to the SDK as `pathToClaudeCodeExecutable`. Any future bundled
+subprocess needs the same treatment — unpacking alone will not fix it.
+
 **A notarization failure that reads like bad credentials**
 Check that the certificate and the API key belong to the *same* Apple team. A
 cross-team mismatch surfaces as an authentication error that never mentions


### PR DESCRIPTION
Every packaged 0.1.1 session died immediately with `Agent session failed to start: spawn ENOTDIR`. Dev builds were fine, because dev has no asar.

## Root cause

Traced by instrumenting `child_process.spawn` in a packaged build:

```
file: .../Memex.app/Contents/Resources/app.asar/node_modules/
      @anthropic-ai/claude-agent-sdk-darwin-arm64/claude
cwd:  /Users/.../memex-test-vault          ← cwd was fine
```

The SDK resolves its bundled `claude` binary relative to its own module path, so inside a packaged app that path runs *through* `app.asar` — a file, not a directory. The OS returns `ENOTDIR` walking into it.

**What is deliberately not the problem:** electron-builder already unpacks that binary, and it's present and executable at `app.asar.unpacked/.../claude` (231 MB, flagged `unpack` in the asar metadata). I checked that first and it disproved my initial "it wasn't unpacked" hypothesis. Electron redirects file *reads* through the asar shim, but **not** the executable handed to `spawn` — so unpacking alone does nothing. The SDK has to be pointed at the unpacked copy.

## Fix

`pathToClaudeCodeExecutable`, supplied by the host in packaged builds only. The path computation lives in `claude-binary.ts` so it can be unit-tested (matching the existing small-module pattern); `main.ts` adds the `isPackaged` guard and an existence check, falling back to the SDK's own resolution — whose error message names the platform it wanted — rather than forcing a bad path.

## Verification

Not just tests — reproduced and fixed against a real packaged build:

1. Built locally, reproduced `spawn ENOTDIR` exactly.
2. Instrumented `spawn` to capture the offending path (above).
3. After the fix, the packaged app started a session and the agent replied to a prompt end-to-end.
4. Repeated that end-to-end check **after** refactoring into `claude-binary.ts`, since that refactor is exactly where a regression would hide.

New regression test asserts the resolved path never traverses `app.asar`, and covers darwin/linux plus the `claude.exe` suffix on Windows. 56 tests pass.

Bumped to 0.1.2. Also documents the failure mode in `docs/RELEASING.md`, with the general lesson: any future bundled subprocess needs the same treatment, because unpacking will not fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)