### PR TITLE
desktop: fix auto-update never running (0.1.3)

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -61,6 +61,22 @@ iterate on the UI. Two optional env vars:
 - `MEMEX_DEVCTL=/path/to/ctlfile` — a JSON control file the app polls; write
   `{"js":"…","shot":"/path/out.png"}` to run code in the window and/or capture a screenshot.
 
+### Dev does not exercise everything
+
+Some code paths only exist in a packaged app, and shipping them unverified has
+bitten this project three times. Anything behind `app.isPackaged`, anything that
+spawns a subprocess, and anything importing a CommonJS dependency needs a real
+packaged run before release — `npm start` cannot catch those failures:
+
+- Paths that traverse `app.asar` cannot be `spawn`ed (Electron redirects file
+  reads into `app.asar.unpacked`, but not the executable given to spawn). See
+  `src/main/claude-binary.ts`.
+- Default-importing a CJS module that sets `__esModule: true` without a
+  `default` export yields `undefined` at runtime (hit with `electron-updater`).
+
+`docs/RELEASING.md` → "Packaged-build gotchas" has the recipe for running and
+driving a packaged build, including how to test auto-update.
+
 ## Customizing tabs & quick-actions
 
 The right panel's tabs *and* the quick-action chips are user-customizable, the Memex way — as a plain

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
   "author": {
     "name": "Arjun Raj",

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -1,6 +1,10 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, protocol } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron';
-import electronUpdater from 'electron-updater';
+// Named import, not default: electron-updater is CJS with `__esModule: true`
+// and no `default` export, so a default import compiles to an undefined value.
+// `autoUpdater` is a lazy getter that constructs on first access, so it must
+// stay a property read that happens after app.whenReady.
+import { autoUpdater } from 'electron-updater';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -534,7 +538,6 @@ function initAutoUpdater(): void {
   // Dev builds have no feed to read: electron-updater throws looking for
   // dev-app-update.yml. Only packaged apps can update.
   if (!app.isPackaged) return;
-  const { autoUpdater } = electronUpdater;
   // A failed update check must stay invisible — it is not something the user
   // asked for or can act on. An unhandled 'error' event would otherwise be
   // thrown. Linux .deb installs land here too: electron-updater only supports

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -357,6 +357,82 @@ A release can only update users who already have an updater-capable build:
 0.1.0 shipped without one, so those installs must be replaced by hand. Every
 release from 0.1.1 onward can carry users forward.
 
+## Packaged-build gotchas, and how to test for them
+
+Three releases in a row shipped bugs that **could not occur in dev**. They share
+one shape: code that only runs in a packaged app, verified only in dev.
+
+> **The rule: anything behind `app.isPackaged`, anything that spawns a
+> subprocess, and anything that imports a CommonJS dependency must be exercised
+> in a real packaged build before release.** `npm start` proves nothing about
+> these.
+
+### Trap 1: paths through `app.asar` can't be spawned
+
+`app.asar` is a file, not a directory. Electron's shim redirects file *reads*
+into `app.asar.unpacked`, but **not** the executable path handed to
+`child_process.spawn`. So a bundled binary fails with `ENOTDIR` even when
+electron-builder has correctly unpacked it — unpacking is necessary but not
+sufficient, and the consumer has to be pointed at the unpacked path explicitly
+(see `src/main/claude-binary.ts`).
+
+Symptom: works in dev, `spawn ENOTDIR` when packaged.
+
+### Trap 2: default-importing a CommonJS dependency
+
+`electron-updater` sets `__esModule: true` but exports no `default`. TypeScript's
+`__importDefault` therefore passes the module through unwrapped, and
+`import x from 'electron-updater'` yields an object whose `.default` is
+`undefined`. Use a **named import**.
+
+Symptom: `TypeError: Cannot destructure property 'autoUpdater' of '..._1.default'
+as it is undefined` — and only at runtime, in packaged builds, because the call
+site sits behind an `isPackaged` guard. Check before trusting a default import:
+
+```bash
+node -e "const m=require('<dep>'); console.log(m.__esModule, m.default!==undefined)"
+```
+
+### How to actually test a packaged build
+
+```bash
+npm run pack                       # builds release/mac-arm64/Memex.app
+
+# Run it from a terminal so main-process console output is visible — launching
+# from Finder hides exactly the errors you are looking for. The separate
+# user-data-dir avoids the single-instance lock stealing your launch when a
+# copy is already installed and running.
+MEMEX_DEV=1 MEMEX_OPEN=~/some-vault \
+  ./release/mac-arm64/Memex.app/Contents/MacOS/Memex \
+  --user-data-dir=/tmp/memex-test-profile 2>&1 | tee /tmp/memex.log
+```
+
+Then **drive the feature**, don't just check that the app launched. A clean
+startup log is not evidence that guarded code works: the ENOTDIR bug and the
+updater crash both sat in an app that started perfectly.
+
+### Testing auto-update specifically
+
+`npm run pack` does not generate `app-update.yml`, so the updater fails with
+`ENOENT` on it. Build a real target instead, with the version temporarily set
+*below* the published release so there is something to find:
+
+```bash
+# temporarily set package.json version to the previous release, then:
+npx electron-builder --mac dmg --arm64 --publish never
+MEMEX_DEV=1 ./release/mac-arm64/Memex.app/Contents/MacOS/Memex \
+  --user-data-dir=/tmp/upd-test 2>&1 | grep -iE "checking|found version|download"
+```
+
+Expect `Checking for update` → `Found version X` → `New version X has been
+downloaded`. An **unsigned** local build then fails at
+`Code signature ... did not pass validation` — that is correct and expected:
+Squirrel.Mac requires the update to carry the same identity as the running app.
+Reaching that line means everything upstream works. Afterwards, clear
+`~/Library/Caches/memex-desktop-updater` and
+`~/Library/Caches/app.memex.desktop.ShipIt` so a stale pending update doesn't
+confuse the next run.
+
 ## Verifying a release before you publish it
 
 CI logs are not proof. electron-builder *skips* signing with a warning rather


### PR DESCRIPTION
Auto-update was dead in **both 0.1.1 and 0.1.2**. Launching the installed app from a terminal showed why immediately:

```
TypeError: Cannot destructure property 'autoUpdater' of 'electron_updater_1.default' as it is undefined
    at initAutoUpdater (.../main.js:642)
```

`electron-updater` is CJS that sets `__esModule: true` but exports no `default`, so TypeScript's `__importDefault` passes the module through unwrapped and `.default` is `undefined`. Confirmed directly:

```
$ node -e "const m=require('electron-updater'); console.log(m.__esModule, m.default!==undefined)"
true false
```

Fixed with a named import, keeping the access lazy — `autoUpdater` is a getter that constructs on first read, so it has to stay after `app.whenReady`.

## Why this shipped twice

`initAutoUpdater()` returns early unless `app.isPackaged`, so the broken line never executed in dev. My verification was "the app starts cleanly in dev", which only proved the *guard* worked and never the behaviour behind it. Same shape as the ENOTDIR bug in #28: dev-only verification of packaged-only code.

## Verified properly this time

Against a real packaged build, with the version temporarily set below the published release so there was genuinely something to find:

```
Checking for update
Found version 0.1.2
Downloading update
New version 0.1.2 has been downloaded to .../pending/Memex-0.1.2-arm64-mac.zip
auto-update check failed: Code signature ... did not pass validation
```

That last line is **expected**: the local test build is unsigned, and Squirrel.Mac requires the update to carry the same identity as the running app. Reaching it means check, discovery, download and staging all work. A signed 0.1.3 updating to a signed 0.1.4 won't hit it.

## Documentation

Adds a **"Packaged-build gotchas"** section to `docs/RELEASING.md` and a pointer in `app/README.md`, covering the general rule rather than just these two bugs: anything behind `app.isPackaged`, anything spawning a subprocess, and anything importing a CJS dependency must be exercised in a packaged build. Includes the recipe for running one (from a terminal, with a separate `--user-data-dir` to dodge the single-instance lock) and for testing auto-update specifically — including that `npm run pack` doesn't emit `app-update.yml`, so you need a real target.

## Note on rollout

0.1.1 and 0.1.2 cannot update themselves, so 0.1.3 has to be installed by hand. **0.1.3 is the first build from which auto-update actually works.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)