### PR TITLE
desktop: show the running version in the vault switcher (0.1.4)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
   "author": {
     "name": "Arjun Raj",

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -727,6 +727,11 @@ function registerIpc(): void {
     return searchVault(vault, String(q ?? ''));
   });
 
+  // Surfaced in the vault switcher so the running version is visible without
+  // digging through Info.plist — which is also how you confirm an auto-update
+  // actually applied.
+  handle('app:version', async () => app.getVersion());
+
   handle('permissions:reset', async () => {
     const vault = activeVaultPath();
     if (!vault) return { ok: false };

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -21,6 +21,7 @@ const api: MemexApi = {
   recentVaults: () => invoke('vault:recent'),
   currentVault: () => invoke('vault:current'),
   resetToolApprovals: () => invoke('permissions:reset'),
+  appVersion: () => invoke('app:version'),
 
   // data panels
   data: (kind: DataKind) => invoke('data:get', kind),

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -177,6 +177,7 @@
       <pre class="setup-log" id="setupLog" style="display:none"></pre>
       <div class="onboard-note">Requires the Memex engine and a logged-in Claude Code CLI. This window drives the same agent you'd get from the terminal.</div>
       <button class="approval-reset" id="resetApprovals" type="button">Reset tool approvals for this vault</button>
+      <div class="app-version" id="appVersion"></div>
     </div>
   </div>
 

--- a/app/src/renderer/renderer.ts
+++ b/app/src/renderer/renderer.ts
@@ -205,6 +205,10 @@ $('resetApprovals').onclick = async () => {
 };
 window.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeOnboard(); });
 
+// Fetched once at startup: the version cannot change while the window is open
+// (an update is applied on quit).
+void M.appVersion().then((v) => { $('appVersion').textContent = v ? `Memex ${v}` : ''; }).catch(() => {});
+
 function applySummary(s: VaultSummary): void {
   const c = s.counts;
   $('cntTasks').textContent = c.openTasks ? String(c.openTasks) : '';

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -504,3 +504,6 @@ body {
 /* close control inside the artifact tab */
 .tab-artifact .tab-close { margin-left: 7px; opacity: .55; padding: 0 2px; font-size: 13px; }
 .tab-artifact .tab-close:hover { opacity: 1; }
+
+/* running version, shown in the vault switcher — also how you confirm an update applied */
+.app-version { margin-top: 10px; text-align: center; color: var(--ink-faint); font: 11px var(--font-ui); letter-spacing: .04em; }

--- a/app/src/shared/types.d.ts
+++ b/app/src/shared/types.d.ts
@@ -148,6 +148,7 @@ interface MemexApi {
   recentVaults(): Promise<{ recent: string[]; last: string | null }>;
   currentVault(): Promise<VaultSummary | null>;
   resetToolApprovals(): Promise<{ ok: boolean }>;
+  appVersion(): Promise<string>;
 
   data(kind: 'summary'): Promise<VaultSummary | null>;
   data(kind: 'briefing'): Promise<BriefingInfo | null>;


### PR DESCRIPTION
The app displayed its version nowhere, so there was no in-app way to tell which build you were running — or, more to the point, to confirm an auto-update had actually applied.

Adds a small dim `Memex <version>` line beneath the existing reset-approvals link in the vault switcher, which is where app-level rather than vault-level information already lives.

Follows the existing IPC shape: an `app:version` handler, `appVersion()` on the preload API, declared in the shared `MemexApi` type so drift is a compile error. Fetched once at startup, since the version can't change while the window is open — updates apply on quit.

## Why this is 0.1.4 rather than an empty version bump

0.1.4 exists to exercise the auto-update path end to end from a real signed install (0.1.3 → 0.1.4). Rather than publish a no-op release for that, this makes the test self-verifying: after the update applies, the vault switcher should read `Memex 0.1.4`.

## Verification

Checked in a **packaged** build, not dev, per the "Packaged-build gotchas" rule added in #29 — the preload/IPC path is exactly the kind of thing that can differ once packaged. The version renders correctly and no console errors appear beyond the expected `app-update.yml` ENOENT that `--dir` builds always produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)