### PR TITLE
desktop: terms-acceptance gate before first use (0.1.5)

### DIFF
--- a/app/legal/manifest.json
+++ b/app/legal/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "effective": "2026-07-26",
+  "summary": ""
+}

--- a/app/legal/privacy.md
+++ b/app/legal/privacy.md
@@ -1,0 +1,149 @@
+# Memex Desktop Privacy Notice
+
+**Effective Date: July 26, 2026**
+
+CytoPixel Software LLC ("CytoPixel," "we," "us," or "our") publishes Memex Desktop, an
+application you install and run on your own computer. This notice explains what happens to
+your information when you use it.
+
+**The short version:**
+
+- **CytoPixel collects nothing.** We operate no servers for Memex. There are no accounts, no
+  telemetry, no analytics, no crash reporting, and no usage tracking of any kind. We do not
+  know that you have installed the application, and we cannot see your files.
+- **Your vault stays on your computer.** The files Memex organizes are ordinary files in a
+  folder you choose. They are never uploaded to us.
+- **Your information does go to Anthropic** — the company that provides the AI agent — using
+  your own Anthropic account. That is how the application works, and it is the most important
+  thing in this notice. See Section 2.
+- **We have nothing to delete.** Because we hold no information about you, there is no
+  account to close and no data for us to export or erase.
+
+## 1. Information CytoPixel Collects
+
+None.
+
+We do not collect personal information, contact information, demographic information, file
+contents, file names, prompts, usage statistics, feature analytics, error reports, crash
+dumps, device identifiers, or IP addresses. The application contains no analytics or
+telemetry code. We have no database of users and no ability to identify you.
+
+We collect information only if you choose to contact us directly, for example by emailing
+support or opening an issue in our public code repository. In that case we have whatever you
+send us, and we use it only to respond to you.
+
+## 2. What Leaves Your Device, and to Whom
+
+Although CytoPixel receives nothing, using the application does send information to other
+parties. There are three, and none of them route through us.
+
+### 2.1 Anthropic — your prompts and your vault contents
+
+The application works by sending information to Anthropic, PBC using **your own** Anthropic
+or Claude account. This includes what you type into the application and **the contents of
+files in your vault** that the AI agent reads while working on your requests. The agent
+chooses which files to read in order to answer you, so any information you place in a vault
+may be sent to Anthropic.
+
+This relationship is directly between you and Anthropic. Anthropic's
+[Privacy Policy](https://www.anthropic.com/legal/privacy) and the terms applicable to your
+plan — [Commercial Terms](https://www.anthropic.com/legal/commercial-terms) for Team,
+Enterprise, and API users, or
+[Consumer Terms of Service](https://www.anthropic.com/legal/consumer-terms) for Free, Pro,
+and Max users — govern that information, including how long Anthropic keeps it and what
+Anthropic may do with it.
+
+**CytoPixel is not a party to that relationship.** We do not receive a copy of that
+information, cannot access it, cannot control its retention or use, and cannot delete or
+retrieve it. Requests concerning information you have sent to Anthropic must go to Anthropic.
+
+Please review the Memex Desktop Terms of Use before placing confidential, regulated, or
+otherwise sensitive information in a vault. Certain categories, including protected health
+information, are prohibited.
+
+### 2.2 GitHub — software update checks
+
+The application checks for new versions by contacting GitHub, where our releases are
+published. As with any request to a website, GitHub receives your IP address and the details
+of the request, and GitHub's own privacy practices apply to it. These checks tell us nothing:
+we do not receive GitHub's logs and cannot identify individual users from them.
+
+### 2.3 Services you choose to open
+
+The application connects to other services only at your direction. This includes links you
+click, which open in your own web browser; pages you configure the application to display;
+and any connectors or integrations you enable inside your own Anthropic account, which
+operate under Anthropic's terms rather than ours. Each of those services handles your
+information according to its own privacy policy.
+
+## 3. Information Stored on Your Device
+
+The application saves a small configuration file in your operating system's standard
+application-data directory. It contains the paths of vaults you have opened recently, which
+vault you last used, which tool approvals you have granted for each vault, and a record that
+you accepted these documents, including the version accepted and the date.
+
+This file never leaves your computer. It is not transmitted to us or to anyone else. You can
+delete it by uninstalling the application and removing its application-data directory.
+
+Your vault itself is ordinary files and folders on your disk, under your control. Deleting
+them is a matter of deleting the folder.
+
+## 4. Cookies and Tracking Technologies
+
+The application is not a website and sets no cookies for its own purposes. We use no web
+beacons, no advertising identifiers, and no third-party analytics or tracking services.
+
+If you configure the application to display an external web page, that page may set cookies
+in the application's isolated browser view, exactly as it would in your browser, and that
+page's own privacy policy applies.
+
+## 5. Disclosure of Information to Third Parties
+
+We do not sell, rent, trade, or share your personal information, because we do not have any.
+We hold no information that could be disclosed to advertisers, data brokers, or business
+partners, and none that could be produced in response to a subpoena or government request.
+
+If CytoPixel were involved in a merger, acquisition, or sale of assets, there would likewise
+be no Memex user information to transfer.
+
+## 6. Data Transfer, Retention, and Deletion
+
+We retain no information about you, so there is nothing for us to transfer across borders,
+nothing to retain, and nothing to delete. You do not need to make a request to us to have
+your information erased.
+
+Information you have sent to Anthropic is retained and deleted according to Anthropic's
+policies. Requests about it should be directed to Anthropic.
+
+## 7. Your Rights
+
+Privacy laws in various jurisdictions, including the European Economic Area, the United
+Kingdom, and several United States states, give individuals rights to access, correct,
+delete, or port their personal information, and to object to certain processing. Those rights
+apply to organizations that hold personal information. Because we hold none, there is nothing
+for us to provide, correct, or delete in response to such a request.
+
+To exercise those rights with respect to information you have sent to Anthropic, contact
+Anthropic. If you believe we hold information about you and wish to inquire, you may contact
+us at the address in Section 10.
+
+## 8. Children's Privacy
+
+The application is not directed to children under 13, and we do not knowingly collect
+information from anyone, including children. See also the eligibility provision in the Memex
+Desktop Terms of Use.
+
+## 9. Changes to This Notice
+
+We may update this notice. When we do, we will update its version and effective date, publish
+the updated notice on our website, and present it to you in the application. Because we hold
+no contact information for you, presenting it in the application is our method of notifying
+you.
+
+## 10. Contact Information
+
+If you have any questions about this notice, please contact us at:
+
+CytoPixel Software LLC
+Email: support@cytopixel.com

--- a/app/legal/terms.md
+++ b/app/legal/terms.md
@@ -1,0 +1,309 @@
+# Memex Desktop Terms of Use
+
+**Last Updated: July 26, 2026**
+
+PLEASE READ THESE TERMS OF USE ("TERMS") CAREFULLY BEFORE INSTALLING OR USING THE MEMEX
+DESKTOP APPLICATION ("SOFTWARE"). INSTALLING OR USING THE SOFTWARE SIGNIFIES YOUR AGREEMENT
+TO BE BOUND BY THESE TERMS. IF YOU DO NOT AGREE TO THESE TERMS, DO NOT INSTALL OR USE THE
+SOFTWARE.
+
+## 1. About These Terms and the Software
+
+CytoPixel Software LLC ("CytoPixel," "we," "us," or "our") publishes Memex Desktop, an
+application you install and run on your own computer. The Software organizes a folder of
+your own files (a "vault") and lets an artificial intelligence agent read from and write to
+that folder on your behalf.
+
+The Software is not a hosted service. CytoPixel operates no servers for it, provides no
+accounts or credentials for it, and does not receive, store, or process the contents of your
+vault. These Terms govern your use of the Software itself. They are an agreement between you
+and CytoPixel only.
+
+"You" means the individual or entity installing or using the Software. If you are using the
+Software on behalf of an organization, you represent that you have authority to bind that
+organization to these Terms.
+
+## 2. License and Ownership
+
+Subject to your compliance with these Terms, CytoPixel grants you a limited, non-exclusive,
+non-transferable, revocable right to install and use the Software for your own purposes,
+personal or commercial. No fee is charged for this right.
+
+The source code for Memex is separately published under the MIT License. **These Terms
+govern the packaged application distributed by CytoPixel; nothing in these Terms limits,
+conditions, or revokes any right granted to you under the MIT License with respect to the
+source code.** If a provision of these Terms conflicts with the MIT License as applied to
+the source code, the MIT License controls as to the source code, and these Terms continue to
+govern the packaged application.
+
+CytoPixel, its contributors, and its licensors retain all right, title, and interest in and
+to their respective contributions to the Software, including all intellectual property
+rights therein. The Software includes components owned by third parties and licensed
+separately, as described in Section 5. Nothing in these Terms transfers ownership of the
+Software or any component of it to you.
+
+## 3. Trademarks
+
+The MIT License grants no rights in names, logos, or trademarks. "Memex," "CytoPixel,"
+"NimbusImage," and the associated logos and designs are marks of CytoPixel Software LLC.
+Nothing in these Terms or in the MIT License grants you the right to use those marks,
+including to name, brand, or promote a modified or derivative version of the Software, or to
+suggest that CytoPixel endorses or is affiliated with any product or distribution that is
+not ours.
+
+## 4. How Memex Works: Anthropic and Your Data
+
+**This section describes the most important thing to understand about the Software. Please
+read it.**
+
+The Software operates by sending information to Anthropic, PBC ("Anthropic") using your own
+Anthropic or Claude account. That information includes the text you type into the Software
+and **the contents of files in your vault** that the agent reads while working on your
+requests. The agent decides which files to read in order to answer you, so any information
+you place in a vault may be transmitted to Anthropic.
+
+Your relationship with Anthropic is directly between you and Anthropic. Anthropic's
+agreements govern that information, including how long Anthropic retains it and the purposes
+for which Anthropic may use it:
+
+- [Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms) (Team,
+  Enterprise, and Claude API users)
+- [Anthropic Consumer Terms of Service](https://www.anthropic.com/legal/consumer-terms)
+  (Free, Pro, and Max users)
+- [Anthropic Privacy Policy](https://www.anthropic.com/legal/privacy)
+- [Anthropic Usage Policy](https://www.anthropic.com/legal/aup)
+
+**CytoPixel is not a party to your agreement with Anthropic.** We do not receive that
+information, cannot access it, cannot control how it is used or how long it is kept, and
+cannot delete it or retrieve it for you. Requests about information you have sent to
+Anthropic must be directed to Anthropic.
+
+You are responsible for reviewing Anthropic's agreements and for deciding whether they are
+acceptable for the information you place in a vault.
+
+## 5. Third-Party Components and Accounts
+
+The Software includes and depends on software licensed by Anthropic, including the Claude
+Agent SDK and a bundled Claude command-line program. Your use of those components is subject
+to Anthropic's agreements listed in Section 4 and to Anthropic's
+[legal and compliance terms for Claude Code](https://code.claude.com/docs/en/legal-and-compliance).
+Those components are owned by Anthropic and are not licensed to you under the MIT License.
+
+Using the Software requires your own Anthropic or Claude account. You are responsible for
+obtaining and maintaining that account in good standing, for all activity conducted under
+it, for any charges or usage limits that apply to it, for complying with Anthropic's Usage
+Policy, and for using an authentication method that Anthropic permits for your plan.
+CytoPixel does not provide, resell, or administer Anthropic accounts, and does not guarantee
+that any particular Anthropic plan, model, or authentication method will remain available or
+continue to work with the Software.
+
+The Software may also connect to other services at your direction, such as pages you choose
+to display in the Software or connectors you enable in your own Anthropic account. Your use
+of those services is governed by their own terms.
+
+## 6. Autonomous Operation; Your Responsibilities
+
+You acknowledge and agree that:
+
+**(a) The agent acts on your files.** The Software creates, modifies, moves, renames, and
+deletes files within your vault directory without asking you to confirm each change. Some
+operations — including running shell commands and reaching outside the vault — prompt you for
+approval, and you may grant standing approval for them.
+
+**(b) You are responsible for backups.** The Software is not a backup system and provides no
+undo guarantee. You are solely responsible for maintaining independent backups of anything
+in your vault that you cannot afford to lose. This is particularly important for any
+directory you designate as a vault that already contains files you care about.
+
+**(c) Output may be wrong.** Artificial intelligence systems produce inaccurate,
+incomplete, and fabricated output. The Software may misinterpret your files, misrepresent
+their contents, act on a mistaken understanding of your request, or generate text that
+appears authoritative but is false. You are responsible for reviewing the agent's actions
+and verifying its output before relying on it.
+
+**(d) Output is not professional advice.** Nothing produced by the Software is medical,
+legal, financial, tax, or other professional advice, and it is not a substitute for
+consultation with a qualified professional.
+
+**(e) You are responsible for what you put in a vault.** You decide which files the agent
+can reach. You represent that you have the right to place that content in a vault and to
+have it transmitted to Anthropic as described in Section 4.
+
+## 7. Prohibited Data and Uses
+
+You shall not use the Software to store, process, or transmit:
+
+**(a) Protected health information.** Protected health information ("PHI") as defined under
+the Health Insurance Portability and Accountability Act ("HIPAA"), or any individually
+identifiable health information. Anthropic covers PHI only where the customer has executed a
+Business Associate Agreement with Anthropic and has Zero Data Retention enabled for its
+organization. Individual users of the Software will not have that coverage, and CytoPixel is
+in no case a business associate with respect to your use of the Software.
+
+**(b) Identifiable patient or research-subject information.** Any personally identifiable
+information of patients or human research subjects, whether or not it constitutes PHI.
+
+**(c) Data you are not permitted to disclose to a third-party artificial intelligence
+provider.** Any information whose transmission to Anthropic would breach applicable law, a
+contract or confidentiality obligation, an institutional review board protocol or informed
+consent document, the Family Educational Rights and Privacy Act ("FERPA"), export control
+regulations, or any similar restriction. Because the agent reads the files in your vault,
+placing such information in a vault is a transmission of it.
+
+You further shall not:
+
+**(d)** rely on the Software for clinical, diagnostic, or treatment purposes, or for any
+purpose where inaccurate output could result in personal injury, death, or damage to
+property or the environment;
+
+**(e)** use the Software in violation of any applicable law or regulation, or in violation
+of Anthropic's Usage Policy, or to circumvent any restriction, usage limit, or
+authentication requirement imposed by Anthropic;
+
+**(f)** use the Software to infringe or misappropriate the intellectual property or privacy
+rights of any third party.
+
+The Software has no ability to inspect or enforce these restrictions, and CytoPixel does not
+monitor your use of it. Compliance is entirely your responsibility.
+
+## 8. Software Updates
+
+The Software checks for updates by contacting GitHub, and may download and install updated
+versions. Updates may add, change, or remove functionality. Continued use of the Software
+after an update constitutes acceptance of that version. CytoPixel is under no obligation to
+provide updates, support, maintenance, or bug fixes, or to continue publishing the Software
+at all.
+
+## 9. Disclaimer of Warranties
+
+THE SOFTWARE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. CYTOPIXEL DOES NOT WARRANT THAT THE
+SOFTWARE WILL MEET YOUR REQUIREMENTS, THAT ITS OPERATION WILL BE UNINTERRUPTED OR
+ERROR-FREE, THAT DEFECTS WILL BE CORRECTED, THAT IT IS FREE OF VIRUSES OR OTHER HARMFUL
+COMPONENTS, OR THAT ANY OUTPUT IT PRODUCES WILL BE ACCURATE, COMPLETE, OR RELIABLE.
+
+CYTOPIXEL SPECIFICALLY DISCLAIMS ALL LIABILITY FOR LOSS, CORRUPTION, DELETION, OR
+MODIFICATION OF YOUR FILES, AND FOR ANY DISCLOSURE OF INFORMATION YOU PLACE IN A VAULT. YOU
+ASSUME THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE SOFTWARE AND AS TO ANY
+ACTION THE AGENT TAKES ON YOUR FILES.
+
+THE SOFTWARE IS NOT INTENDED FOR USE IN CLINICAL OR DIAGNOSTIC SETTINGS, AND CYTOPIXEL
+DISCLAIMS ALL LIABILITY ARISING FROM ANY SUCH USE. NO INFORMATION OR ADVICE GIVEN BY
+CYTOPIXEL OR ITS REPRESENTATIVES SHALL CREATE A WARRANTY.
+
+CYTOPIXEL MAKES NO WARRANTY OR REPRESENTATION WHATSOEVER REGARDING ANTHROPIC OR ANY OTHER
+THIRD-PARTY SERVICE, INCLUDING ITS AVAILABILITY, ITS PRICING, ITS HANDLING OF YOUR
+INFORMATION, OR ITS CONTINUED COMPATIBILITY WITH THE SOFTWARE.
+
+## 10. Limitation of Liability
+
+### 10.1 Limitation of Damages
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL CYTOPIXEL, ITS
+AFFILIATES, OFFICERS, DIRECTORS, EMPLOYEES, AGENTS, CONTRIBUTORS, OR LICENSORS BE LIABLE FOR
+ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT
+LIMITED TO DAMAGES FOR LOSS OF PROFITS, GOODWILL, DATA, FILES, RESEARCH, USE, OR OTHER
+INTANGIBLE LOSSES, ARISING OUT OF OR IN CONNECTION WITH THESE TERMS OR THE USE OF OR
+INABILITY TO USE THE SOFTWARE, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING
+NEGLIGENCE), STRICT LIABILITY, OR ANY OTHER LEGAL THEORY, EVEN IF CYTOPIXEL HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### 10.2 Cap on Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, CYTOPIXEL'S TOTAL CUMULATIVE LIABILITY
+ARISING OUT OF OR IN CONNECTION WITH THESE TERMS OR THE USE OF THE SOFTWARE SHALL NOT EXCEED
+THE GREATER OF (A) THE TOTAL AMOUNT OF FEES YOU HAVE PAID TO CYTOPIXEL FOR THE SOFTWARE, IF
+ANY, OR (B) ONE HUNDRED UNITED STATES DOLLARS (US$100). THE FOREGOING LIMITATIONS SHALL
+APPLY NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY AND SHALL APPLY
+EVEN IF A PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### 10.3 Third-Party Services
+
+CYTOPIXEL SHALL HAVE NO LIABILITY WHATSOEVER ARISING OUT OF OR IN CONNECTION WITH ANTHROPIC
+OR ANY OTHER THIRD-PARTY SERVICE, INCLUDING ANY ACT OR OMISSION OF ANTHROPIC, ANY USE OR
+RETENTION OF YOUR INFORMATION BY ANTHROPIC, ANY SUSPENSION OR TERMINATION OF YOUR ANTHROPIC
+ACCOUNT, ANY CHANGE TO ANTHROPIC'S TERMS, PRICING, MODELS, OR AUTHENTICATION REQUIREMENTS,
+OR ANY INTERRUPTION OF ANTHROPIC'S SERVICES.
+
+## 11. Indemnification
+
+You agree to indemnify, defend, and hold harmless CytoPixel, its affiliates, officers,
+directors, employees, agents, contributors, and licensors from and against any and all
+claims, liabilities, damages, losses, costs, and expenses (including reasonable attorneys'
+fees and costs) arising out of or in connection with: (a) your use of the Software in
+violation of these Terms; (b) your violation of any applicable law or regulation, or of
+Anthropic's terms or Usage Policy; (c) any content you place in a vault or otherwise
+transmit through the Software, including any content prohibited by Section 7; or (d) any
+allegation that your use of the Software infringes or misappropriates the intellectual
+property rights of any third party.
+
+## 12. Term and Termination
+
+These Terms take effect when you first install or use the Software and continue until
+terminated.
+
+You may terminate these Terms at any time by ceasing all use of the Software and
+uninstalling it. No fees are charged and none are refundable. Uninstalling the Software does
+not delete your vault, which remains on your computer, and does not affect information
+already transmitted to Anthropic.
+
+CytoPixel may terminate the rights granted in these Terms if you materially breach them.
+Upon termination, your right to use the Software immediately ceases.
+
+Sections 2, 3, 4, 7, 9, 10, 11, 14, and 15 survive any termination of these Terms.
+
+## 13. Changes to These Terms
+
+CytoPixel may modify these Terms. When we do, we will update the version and effective date
+of these Terms, publish the updated Terms on our website, and present them to you in the
+Software. Your continued use of the Software after being presented with updated Terms
+constitutes acceptance of them. If you do not agree to the updated Terms, you must stop
+using the Software and uninstall it. Because the Software runs entirely on your computer and
+we hold no account or contact information for you, presenting the updated Terms in the
+Software is our method of notifying you.
+
+## 14. Governing Law and Jurisdiction
+
+These Terms shall be governed by and construed in accordance with the laws of the State of
+Delaware, United States, without regard to its conflict of laws principles. Any legal action
+or proceeding arising out of or relating to these Terms shall be instituted exclusively in
+the federal or state courts located in the State of Delaware, and each party irrevocably
+consents to the exclusive jurisdiction and venue of such courts. The parties expressly
+exclude the application of the United Nations Convention on Contracts for the International
+Sale of Goods.
+
+## 15. General
+
+**Entire agreement.** These Terms, together with the Memex Privacy Notice, constitute the
+entire agreement between you and CytoPixel regarding the Software and supersede all prior
+understandings regarding it. They do not govern your separate agreements with Anthropic or
+any other third party.
+
+**Severability.** If any provision of these Terms is held unenforceable, that provision
+shall be limited or eliminated to the minimum extent necessary and the remaining provisions
+shall remain in full force and effect.
+
+**No waiver.** Our failure to enforce any provision of these Terms shall not constitute a
+waiver of it.
+
+**Assignment.** You may not assign or transfer these Terms without our prior written
+consent. CytoPixel may assign these Terms in connection with a merger, acquisition, or sale
+of assets.
+
+**Export compliance.** You represent that you are not located in, and will not use the
+Software in, any jurisdiction subject to a United States embargo, and that you are not
+listed on any United States government list of prohibited or restricted parties.
+
+**Eligibility.** The Software is not directed to children. You represent that you are at
+least 18 years old, or the age of majority in your jurisdiction if greater.
+
+## 16. Contact Information
+
+If you have any questions about these Terms, please contact us at:
+
+CytoPixel Software LLC
+Email: support@cytopixel.com
+
+By installing or using the Software, you acknowledge that you have read these Terms,
+understood them, and agree to be bound by them.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memex-desktop",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memex-desktop",
-      "version": "0.1.0",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.211",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memex-desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
   "author": {
     "name": "Arjun Raj",

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "description": "Desktop app for Memex — install, set up, and drive your second brain with a chat + dashboards UI on top of the Claude agent.",
   "author": {
     "name": "Arjun Raj",
-    "email": "arjunrajlab@gmail.com"
+    "email": "araj@cytopixel.com"
   },
   "license": "MIT",
   "homepage": "https://github.com/arjunrajlaboratory/Memex",

--- a/app/scripts/copy-assets.js
+++ b/app/scripts/copy-assets.js
@@ -11,3 +11,13 @@ fs.mkdirSync(dest, { recursive: true });
 for (const file of ['index.html', 'styles.css']) {
   fs.copyFileSync(path.join(src, file), path.join(dest, file));
 }
+
+// The terms/privacy documents are read at runtime by src/main/legal.ts and shown in
+// the acceptance gate, so they have to land in dist/ like any other static asset.
+const legalSrc = path.join(__dirname, '..', 'legal');
+const legalDest = path.join(__dirname, '..', 'dist', 'legal');
+
+fs.mkdirSync(legalDest, { recursive: true });
+for (const file of ['manifest.json', 'terms.md', 'privacy.md']) {
+  fs.copyFileSync(path.join(legalSrc, file), path.join(legalDest, file));
+}

--- a/app/src/main/legal.ts
+++ b/app/src/main/legal.ts
@@ -1,0 +1,52 @@
+// Terms-acceptance decision logic. Deliberately free of electron imports so the
+// whole decision surface is unit-testable: main.ts asks this module, and the gate
+// overlay in the renderer is only how the user satisfies the answer.
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface LegalManifest { version: string; effective: string; summary: string; }
+export interface LegalDocs { manifest: LegalManifest; terms: string; privacy: string; }
+export interface TermsAcceptance { version: string; acceptedAt: string; appVersion: string; }
+
+/** Reads a bundled legal directory. Returns null if anything is missing or unusable. */
+export function loadLegal(dir: string): LegalDocs | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(dir, 'manifest.json'), 'utf8')) as Partial<LegalManifest>;
+    const version = typeof raw.version === 'string' ? raw.version.trim() : '';
+    if (!version) return null;
+    const terms = fs.readFileSync(path.join(dir, 'terms.md'), 'utf8');
+    const privacy = fs.readFileSync(path.join(dir, 'privacy.md'), 'utf8');
+    if (!terms.trim() || !privacy.trim()) return null;
+    return {
+      manifest: {
+        version,
+        effective: typeof raw.effective === 'string' ? raw.effective : '',
+        summary: typeof raw.summary === 'string' ? raw.summary : '',
+      },
+      terms,
+      privacy,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Fails closed. A missing manifest, an unreadable document, or a record of the
+ * wrong shape all mean "show the gate": re-reading the terms is a nuisance,
+ * shipping a build that never shows them is not.
+ *
+ * Plain inequality rather than a semver comparison, so any declared-version
+ * change re-prompts — including a rollback.
+ */
+export function needsAcceptance(accepted: unknown, manifest: LegalManifest | null): boolean {
+  if (!manifest || !manifest.version) return true;
+  if (!accepted || typeof accepted !== 'object') return true;
+  const version = (accepted as { version?: unknown }).version;
+  if (typeof version !== 'string' || !version.trim()) return true;
+  return version !== manifest.version;
+}
+
+export function acceptanceRecord(manifest: LegalManifest, appVersion: string, now: Date): TermsAcceptance {
+  return { version: manifest.version, acceptedAt: now.toISOString(), appVersion: String(appVersion || '') };
+}

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -25,6 +25,7 @@ import { classifyVaultChange } from './watch-policy';
 import { buildWikiIndex } from './wiki-index';
 import { SerialQueue } from './serial-queue';
 import { unpackedClaudeBinaryPath } from './claude-binary';
+import { acceptanceRecord, loadLegal, needsAcceptance, type LegalDocs, type TermsAcceptance } from './legal';
 
 const fsp = fs.promises;
 // Development runs inside the engine checkout; packaged builds carry the exact
@@ -34,8 +35,9 @@ const ENGINE_ROOT = app.isPackaged
   : path.resolve(__dirname, '..', '..', '..');
 const RENDERER_PATH = path.join(__dirname, '..', 'renderer', 'index.html');
 const CONFIG_PATH = () => path.join(app.getPath('userData'), 'config.json');
+const LEGAL_DIR = path.join(__dirname, '..', 'legal');
 
-interface PersistedConfig extends ToolGrantState { recent?: string[]; last?: string; }
+interface PersistedConfig extends ToolGrantState { recent?: string[]; last?: string; terms?: TermsAcceptance; }
 
 // Node's fs does not expand a leading ~, but the user's placeholder path is ~/…,
 // so expand it wherever a user-supplied path enters the main process.
@@ -54,6 +56,18 @@ let watchers: fs.FSWatcher[] = [];
 let watcherRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let shuttingDown = false;
 let mdRenderer: ((md: string) => string) | null = null;
+// `undefined` = not yet read, `null` = read and unusable. Cached because the
+// documents cannot change without a new build.
+let legalDocs: LegalDocs | null | undefined;
+function legal(): LegalDocs | null {
+  if (legalDocs === undefined) legalDocs = loadLegal(LEGAL_DIR);
+  return legalDocs;
+}
+// The gate is enforced here, not in the renderer: MEMEX_OPEN and any UI bug
+// would otherwise sail straight past a purely visual overlay.
+function termsAccepted(): boolean {
+  return !needsAcceptance(loadConfig().terms, legal()?.manifest || null);
+}
 // Files dropped on the Dock icon (mac) or taskbar/exe (Windows) before any vault is open;
 // flushed into the Inbox once vault:open succeeds.
 let pendingDrops: string[] = [];
@@ -157,7 +171,7 @@ function filterRows<T extends FilterableRow>(rows: T[], where: QueryWhere | null
 }
 
 // ---------- markdown -> safe html ----------
-async function renderMarkdown(md: string): Promise<string> {
+async function ensureMarkdownRenderer(): Promise<(md: string) => string> {
   if (!mdRenderer) {
     const { marked, Renderer } = await import('marked');
     const renderer = new Renderer();
@@ -165,7 +179,19 @@ async function renderMarkdown(md: string): Promise<string> {
     marked.setOptions({ breaks: true, gfm: true, renderer });
     mdRenderer = (s: string) => marked.parse(s) as string;
   }
-  return mdRenderer(await linkifyWikilinks(md || ''));
+  return mdRenderer;
+}
+
+async function renderMarkdown(md: string): Promise<string> {
+  const render = await ensureMarkdownRenderer();
+  return render(await linkifyWikilinks(md || ''));
+}
+
+// Legal documents contain no wikilinks and are shown before any vault is open,
+// so they skip the vault-scoped wikilink pass entirely.
+async function renderPlainMarkdown(md: string): Promise<string> {
+  const render = await ensureMarkdownRenderer();
+  return render(md || '');
 }
 
 // ---------- window ----------
@@ -699,6 +725,40 @@ function registerIpc(): void {
     return r.canceled ? null : r.filePaths[0];
   });
 
+  handle('legal:state', async (): Promise<LegalState> => {
+    const docs = legal();
+    if (!docs) {
+      // Fail closed and say so, rather than silently letting the user through.
+      return {
+        needsAcceptance: true, version: '', effective: '', summary: '',
+        terms: '<p>The Terms of Use could not be loaded, so Memex cannot continue. Please reinstall the app.</p>',
+        privacy: '<p>The Privacy Notice could not be loaded, so Memex cannot continue. Please reinstall the app.</p>',
+      };
+    }
+    const cfg = loadConfig();
+    return {
+      needsAcceptance: needsAcceptance(cfg.terms, docs.manifest),
+      version: docs.manifest.version,
+      effective: docs.manifest.effective,
+      // "What changed" is meaningless on a first run — only show it to someone
+      // who accepted an earlier version.
+      summary: cfg.terms ? docs.manifest.summary : '',
+      terms: await renderPlainMarkdown(docs.terms),
+      privacy: await renderPlainMarkdown(docs.privacy),
+    };
+  });
+
+  handle('legal:accept', async () => {
+    const docs = legal();
+    if (!docs) return { ok: false };
+    const cfg = loadConfig();
+    cfg.terms = acceptanceRecord(docs.manifest, app.getVersion(), new Date());
+    saveConfig(cfg);
+    return { ok: true };
+  });
+
+  handle('app:quit', async () => { app.quit(); });
+
   handle('vault:detect', async (_e, p: string) => {
     const full = expandHome(p);
     return { path: full, isVault: vaultLib.isVault(full) };
@@ -740,11 +800,13 @@ function registerIpc(): void {
   });
 
   handle('vault:create', async (_e, opts: { target: string; answers: Record<string, string>; packs: string }) => {
+    if (!termsAccepted()) return { ok: false, code: -1, output: 'Please accept the Terms of Use to continue.' };
     const res = await createVault({ ...opts, target: expandHome(opts.target) });
     return res;
   });
 
   handle('vault:open', async (_e, p: string) => {
+    if (!termsAccepted()) return { ok: false, error: 'Please accept the Terms of Use to continue' };
     const full = expandHome(p);
     if (!vaultLib.isVault(full)) return { ok: false, error: 'Not a Memex vault' };
     let summary: VaultSummary;

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -754,7 +754,12 @@ function registerIpc(): void {
     const cfg = loadConfig();
     cfg.terms = acceptanceRecord(docs.manifest, app.getVersion(), new Date());
     saveConfig(cfg);
-    return { ok: true };
+    // saveConfig swallows write errors, so re-read from disk and ask the same
+    // question the vault guards ask. Claiming success on an unwritable config
+    // would close the gate while vault:open and vault:create keep refusing,
+    // and review mode hides the consent controls — the user would be stuck
+    // until they restarted.
+    return { ok: termsAccepted() };
   });
 
   handle('app:quit', async () => { app.quit(); });

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -22,6 +22,9 @@ const api: MemexApi = {
   currentVault: () => invoke('vault:current'),
   resetToolApprovals: () => invoke('permissions:reset'),
   appVersion: () => invoke('app:version'),
+  legalState: () => invoke('legal:state'),
+  legalAccept: () => invoke('legal:accept'),
+  legalQuit: () => invoke('app:quit'),
 
   // data panels
   data: (kind: DataKind) => invoke('data:get', kind),

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -162,6 +162,7 @@
                 <input id="f_path" placeholder="~/code/my-vault" required />
                 <button type="button" class="btn tiny" id="pickPath">…</button>
               </div>
+              <span class="field-hint">Doesn't exist yet? Memex creates it for you, including parent folders.</span>
             </label>
             <label class="pack-row">Packs
               <span class="pack-opts">
@@ -177,12 +178,53 @@
       <pre class="setup-log" id="setupLog" style="display:none"></pre>
       <div class="onboard-note">Requires the Memex engine and a logged-in Claude Code CLI. This window drives the same agent you'd get from the terminal.</div>
       <button class="approval-reset" id="resetApprovals" type="button">Reset tool approvals for this vault</button>
+      <button class="legal-link" id="legalReview" type="button">Terms of Use · Privacy</button>
       <div class="app-version" id="appVersion"></div>
+    </div>
+  </div>
+
+  <!-- ======================= TERMS GATE ======================= -->
+  <div class="legal" id="legalGate" style="display:none">
+    <div class="legal-inner">
+      <div class="legal-head">
+        <div class="wordmark big"><span class="mark">Memex</span></div>
+        <h2 class="legal-title">Before you start</h2>
+        <p class="legal-eff" id="legalEffective"></p>
+        <p class="legal-changed" id="legalChanged" style="display:none"></p>
+      </div>
+
+      <div class="legal-tabs">
+        <button class="legal-tab active" id="legalTabTerms" type="button">Terms of Use</button>
+        <button class="legal-tab" id="legalTabPrivacy" type="button">Privacy Notice</button>
+      </div>
+
+      <div class="legal-doc" id="legalDoc"></div>
+
+      <p class="legal-online">
+        Also published at
+        <a href="https://cytopixel.com/terms-of-service/">cytopixel.com/terms-of-service</a> and
+        <a href="https://cytopixel.com/privacy-policy/">cytopixel.com/privacy-policy</a>.
+      </p>
+
+      <div class="legal-foot">
+        <div id="legalConsent">
+          <label class="legal-agree">
+            <input type="checkbox" id="legalAgree" />
+            <span>I have read and agree to the Memex Terms of Use and Privacy Notice.</span>
+          </label>
+          <div class="legal-actions">
+            <button class="btn ghost" id="legalDecline" type="button">Decline and quit</button>
+            <button class="btn primary" id="legalAcceptBtn" type="button" disabled>Agree and continue</button>
+          </div>
+        </div>
+        <button class="btn ghost legal-close" id="legalClose" type="button" style="display:none">Close</button>
+      </div>
     </div>
   </div>
 
   <script src="../shared/area-batch.js"></script>
   <script src="../shared/vault-ui-state.js"></script>
   <script src="renderer.js"></script>
+  <script src="legal-gate.js"></script>
 </body>
 </html>

--- a/app/src/renderer/legal-gate.ts
+++ b/app/src/renderer/legal-gate.ts
@@ -1,0 +1,90 @@
+// The terms-acceptance gate. Compiled as a plain (non-module) script like
+// renderer.ts, so everything lives inside one IIFE: top-level names in these
+// files share a single global scope, and `$`/`el`/`M` are already taken.
+//
+// Self-contained on purpose — it owns its markup, its wiring, and the
+// vault-switcher link that reopens it read-only, so renderer.ts needs to know
+// nothing about it. Enforcement is in the main process (vault:open and
+// vault:create refuse until terms are accepted); this overlay is only how the
+// user satisfies that check.
+(() => {
+  const api = window.memex;
+  const id = (name: string): HTMLElement => document.getElementById(name) as HTMLElement;
+
+  const gate = id('legalGate');
+  const docPane = id('legalDoc');
+  const agree = id('legalAgree') as HTMLInputElement;
+  const acceptBtn = id('legalAcceptBtn') as HTMLButtonElement;
+  const closeBtn = id('legalClose') as HTMLButtonElement;
+  const tabTerms = id('legalTabTerms');
+  const tabPrivacy = id('legalTabPrivacy');
+
+  let rendered = { terms: '', privacy: '' };
+
+  // The documents are HTML rendered by the main process through the hardened
+  // marked renderer, which strips raw HTML and admits only vetted links.
+  const showDoc = (which: 'terms' | 'privacy'): void => {
+    docPane.innerHTML = which === 'terms' ? rendered.terms : rendered.privacy;
+    docPane.scrollTop = 0;
+    tabTerms.classList.toggle('active', which === 'terms');
+    tabPrivacy.classList.toggle('active', which === 'privacy');
+  };
+
+  const open = (mode: 'gate' | 'review', state: LegalState): void => {
+    rendered = { terms: state.terms, privacy: state.privacy };
+    id('legalEffective').textContent = state.version
+      ? `Version ${state.version}${state.effective ? ` · effective ${state.effective}` : ''}`
+      : '';
+
+    // "What changed" only helps someone who accepted an earlier version; the
+    // main process leaves `summary` empty on a first run.
+    const changed = id('legalChanged');
+    const showChanged = mode === 'gate' && !!state.summary;
+    changed.textContent = showChanged ? `What changed: ${state.summary}` : '';
+    changed.style.display = showChanged ? '' : 'none';
+
+    agree.checked = false;
+    acceptBtn.disabled = true;
+    id('legalConsent').style.display = mode === 'gate' ? '' : 'none';
+    closeBtn.style.display = mode === 'gate' ? 'none' : '';
+
+    showDoc('terms');
+    gate.style.display = 'grid';
+    // Keep focus and screen readers inside the gate while it is up.
+    id('workspace').inert = true;
+    id('onboard').inert = true;
+    (mode === 'gate' ? agree : closeBtn).focus();
+  };
+
+  const close = (): void => {
+    gate.style.display = 'none';
+    id('workspace').inert = false;
+    id('onboard').inert = false;
+  };
+
+  tabTerms.onclick = () => showDoc('terms');
+  tabPrivacy.onclick = () => showDoc('privacy');
+  agree.onchange = () => { acceptBtn.disabled = !agree.checked; };
+
+  acceptBtn.onclick = async () => {
+    acceptBtn.disabled = true;
+    const res = await api.legalAccept();
+    if (res.ok) { close(); return; }
+    // Recording failed, which means the documents are unreadable. Do not let the
+    // user through — the main process would refuse to open a vault anyway — and
+    // say why instead of leaving a dead button.
+    agree.checked = false;
+    const changed = id('legalChanged');
+    changed.textContent = 'Memex could not record your acceptance. Please reinstall the app.';
+    changed.style.display = '';
+  };
+
+  id('legalDecline').onclick = () => { void api.legalQuit(); };
+  closeBtn.onclick = close;
+  id('legalReview').onclick = async () => { open('review', await api.legalState()); };
+
+  void (async () => {
+    const state = await api.legalState();
+    if (state.needsAcceptance) open('gate', state);
+  })();
+})();

--- a/app/src/renderer/legal-gate.ts
+++ b/app/src/renderer/legal-gate.ts
@@ -21,6 +21,36 @@
 
   let rendered = { terms: '', privacy: '' };
 
+  // Everything outside the gate. The title bar is included: it is not part of
+  // #workspace, so leaving it live let you switch vaults and toggle the theme
+  // from behind a supposedly blocking dialog, and let Tab wrap out of the gate.
+  const chrome = (): Element[] => [
+    id('workspace'),
+    id('onboard'),
+    ...Array.from(document.querySelectorAll('.titlebar')),
+  ];
+  const setChromeInert = (on: boolean): void => {
+    for (const el of chrome()) (el as HTMLElement).inert = on;
+  };
+
+  const isOpen = (): boolean => gate.style.display !== 'none';
+
+  // renderer.ts binds Cmd/Ctrl-K (search), Cmd/Ctrl-[ and -] (history), and
+  // Escape (close the vault switcher) on window in the bubble phase. Search in
+  // particular would open its own overlay and pull focus out of the gate. A
+  // capture-phase listener runs before those, so the gate can swallow exactly
+  // those chords while it is up — and nothing else, so Tab still moves within
+  // the gate and Cmd-C still copies the terms.
+  window.addEventListener('keydown', (e) => {
+    if (!isOpen()) return;
+    const chord = (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey
+      && (e.key === 'k' || e.key === 'K' || e.key === '[' || e.key === ']');
+    if (chord || e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, true);
+
   // The documents are HTML rendered by the main process through the hardened
   // marked renderer, which strips raw HTML and admits only vetted links.
   const showDoc = (which: 'terms' | 'privacy'): void => {
@@ -50,16 +80,13 @@
 
     showDoc('terms');
     gate.style.display = 'grid';
-    // Keep focus and screen readers inside the gate while it is up.
-    id('workspace').inert = true;
-    id('onboard').inert = true;
+    setChromeInert(true);
     (mode === 'gate' ? agree : closeBtn).focus();
   };
 
   const close = (): void => {
     gate.style.display = 'none';
-    id('workspace').inert = false;
-    id('onboard').inert = false;
+    setChromeInert(false);
   };
 
   tabTerms.onclick = () => showDoc('terms');
@@ -70,12 +97,13 @@
     acceptBtn.disabled = true;
     const res = await api.legalAccept();
     if (res.ok) { close(); return; }
-    // Recording failed, which means the documents are unreadable. Do not let the
-    // user through — the main process would refuse to open a vault anyway — and
-    // say why instead of leaving a dead button.
+    // The main process confirmed the record did not reach disk, so it will keep
+    // refusing to open a vault. Do not close the gate — say why, and leave the
+    // checkbox re-tickable so this is retryable once the cause is fixed.
     agree.checked = false;
     const changed = id('legalChanged');
-    changed.textContent = 'Memex could not record your acceptance. Please reinstall the app.';
+    changed.textContent = 'Memex could not save your acceptance. Check that your disk is not full '
+      + 'and that Memex can write to its application-data folder, then try again.';
     changed.style.display = '';
   };
 

--- a/app/src/renderer/renderer.ts
+++ b/app/src/renderer/renderer.ts
@@ -81,7 +81,7 @@ $('browseVault').onclick = async () => {
   if (!p) return;
   const det = await M.detectVault(p);
   if (det.isVault) openVault(p);
-  else { ($('f_path') as HTMLInputElement).value = p; flash('That folder isn\'t a vault yet — create one here, or pick a vault folder.'); }
+  else { ($('f_path') as HTMLInputElement).value = p; flash('That folder isn\'t a Memex vault yet. The form on the right can set one up there, or pick another folder.'); }
 };
 
 $('pickPath').onclick = async () => { const p = await M.pickDirectory(); if (p) ($('f_path') as HTMLInputElement).value = p; };

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -507,3 +507,48 @@ body {
 
 /* running version, shown in the vault switcher — also how you confirm an update applied */
 .app-version { margin-top: 10px; text-align: center; color: var(--ink-faint); font: 11px var(--font-ui); letter-spacing: .04em; }
+
+/* ======================= TERMS GATE ======================= */
+/* Above .onboard (z-index 20): the gate must cover the vault switcher too. */
+.legal { position: fixed; inset: 0; z-index: 40; background: radial-gradient(ellipse at 30% 0%, var(--bg-2), var(--bg)); display: grid; place-items: center; overflow: auto; }
+.legal-inner { width: min(760px, 92vw); padding: 34px 0; }
+.legal-head { text-align: center; margin-bottom: 20px; }
+/* .wordmark is a flex container, so text-align on the parent does not center it. */
+.legal-head .wordmark { justify-content: center; }
+.legal-title { font-family: var(--font-display); font-size: 24px; font-weight: 600; color: var(--ink); margin: 14px 0 6px; }
+.legal-eff { font-size: 12px; color: var(--ink-faint); margin: 0; }
+.legal-changed { font-size: 13px; line-height: 1.6; color: var(--ink-dim); max-width: 520px; margin: 12px auto 0; }
+.legal-tabs { display: flex; gap: 8px; margin-bottom: 12px; }
+.legal-tab { padding: 7px 14px; border: 1px solid var(--line); border-radius: 20px; background: transparent; color: var(--ink-dim); font: 12.5px var(--font-ui); cursor: pointer; }
+.legal-tab.active { border-color: var(--accent); background: var(--accent-soft); color: var(--ink); }
+.legal-doc {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
+  padding: 20px 26px; max-height: 46vh; overflow: auto;
+  font-size: 13px; line-height: 1.7; color: var(--ink-dim);
+}
+.legal-doc h1 { font-family: var(--font-display); font-size: 20px; color: var(--ink); margin: 0 0 10px; }
+.legal-doc h2 { font-size: 14px; color: var(--ink); margin: 22px 0 8px; }
+.legal-doc h3 { font-size: 13px; color: var(--ink); margin: 16px 0 6px; }
+.legal-doc p, .legal-doc li { margin: 8px 0; }
+.legal-doc ul, .legal-doc ol { padding-left: 22px; }
+.legal-doc strong { color: var(--ink); }
+.legal-doc a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
+.legal-doc hr { border: none; border-top: 1px solid var(--line); margin: 20px 0; }
+/* Plain <a href>: renderer.ts's document-level click handler already delegates
+   http(s) links to the system browser, so these need no wiring of their own. */
+.legal-online { font-size: 11.5px; color: var(--ink-faint); margin: 10px 0 0; text-align: center; }
+.legal-online a { color: var(--ink-dim); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
+.legal-foot { margin-top: 18px; }
+.legal-agree { display: flex; align-items: flex-start; gap: 9px; font-size: 13px; line-height: 1.5; color: var(--ink-dim); cursor: pointer; }
+.legal-agree input { margin-top: 2px; }
+.legal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px; }
+/* .btn.ghost is width:100% for the onboard cards; in this row the buttons size to content. */
+.legal-actions .btn, .legal-close { width: auto; }
+/* The consent button spends most of its life disabled — it has to look it, or an
+   unticked checkbox reads as a broken button. No global .btn:disabled rule exists. */
+.legal-actions .btn:disabled { opacity: .38; cursor: not-allowed; filter: none; }
+.legal-actions .btn:disabled:hover { border-color: var(--accent); filter: none; }
+.legal-close { display: block; margin: 0 auto; }
+.legal-link { display: block; margin: 9px auto 0; padding: 2px 4px; border: 0; background: transparent; color: var(--ink-faint); font: 11px var(--font-ui); text-decoration: underline; cursor: pointer; }
+.legal-link:hover { color: var(--ink-dim); }
+.field-hint { font-size: 11.5px; line-height: 1.5; color: var(--ink-faint); }

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -509,8 +509,10 @@ body {
 .app-version { margin-top: 10px; text-align: center; color: var(--ink-faint); font: 11px var(--font-ui); letter-spacing: .04em; }
 
 /* ======================= TERMS GATE ======================= */
-/* Above .onboard (z-index 20): the gate must cover the vault switcher too. */
-.legal { position: fixed; inset: 0; z-index: 40; background: radial-gradient(ellipse at 30% 0%, var(--bg-2), var(--bg)); display: grid; place-items: center; overflow: auto; }
+/* Topmost on purpose. It has to sit above .onboard (20), .search-overlay (60),
+   and .drop-overlay (9999): anything that can render over the gate is a way to
+   interact with the app without having accepted the terms. */
+.legal { position: fixed; inset: 0; z-index: 10000; background: radial-gradient(ellipse at 30% 0%, var(--bg-2), var(--bg)); display: grid; place-items: center; overflow: auto; }
 .legal-inner { width: min(760px, 92vw); padding: 34px 0; }
 .legal-head { text-align: center; margin-bottom: 20px; }
 /* .wordmark is a flex container, so text-align on the parent does not center it. */

--- a/app/src/shared/types.d.ts
+++ b/app/src/shared/types.d.ts
@@ -132,6 +132,17 @@ interface OpenVaultResult {
   pendingDrop?: DropResult;
 }
 interface CreateVaultResult { ok: boolean; code: number; output: string; }
+
+// Terms/privacy state for the acceptance gate. `terms` and `privacy` are HTML
+// rendered by the main process, not markdown.
+interface LegalState {
+  needsAcceptance: boolean;
+  version: string;
+  effective: string;
+  summary: string;
+  terms: string;
+  privacy: string;
+}
 interface DropResult { ok: boolean; copied?: string[]; error?: string; }
 interface SendResult { ok: boolean; error?: string; }
 
@@ -149,6 +160,9 @@ interface MemexApi {
   currentVault(): Promise<VaultSummary | null>;
   resetToolApprovals(): Promise<{ ok: boolean }>;
   appVersion(): Promise<string>;
+  legalState(): Promise<LegalState>;
+  legalAccept(): Promise<{ ok: boolean }>;
+  legalQuit(): Promise<void>;
 
   data(kind: 'summary'): Promise<VaultSummary | null>;
   data(kind: 'briefing'): Promise<BriefingInfo | null>;

--- a/app/test/legal.test.cjs
+++ b/app/test/legal.test.cjs
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LEGAL_DIST = path.join(__dirname, '..', 'dist', 'legal');
+
+test('the build bundles the legal documents into dist/legal', () => {
+  for (const file of ['manifest.json', 'terms.md', 'privacy.md']) {
+    assert.ok(fs.existsSync(path.join(LEGAL_DIST, file)), `dist/legal/${file} must exist after a build`);
+  }
+});
+
+test('the bundled manifest declares a version and effective date', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(LEGAL_DIST, 'manifest.json'), 'utf8'));
+  assert.match(manifest.version, /^\d+\.\d+$/);
+  assert.match(manifest.effective, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(typeof manifest.summary, 'string');
+});
+
+test('the bundled documents are the real ones, not placeholders', () => {
+  const terms = fs.readFileSync(path.join(LEGAL_DIST, 'terms.md'), 'utf8');
+  const privacy = fs.readFileSync(path.join(LEGAL_DIST, 'privacy.md'), 'utf8');
+  assert.match(terms, /# Memex Desktop Terms of Use/);
+  assert.match(privacy, /# Memex Desktop Privacy Notice/);
+  // The Anthropic data-flow disclosure is the reason this gate exists.
+  assert.match(terms, /Anthropic/);
+});

--- a/app/test/legal.test.cjs
+++ b/app/test/legal.test.cjs
@@ -26,3 +26,78 @@ test('the bundled documents are the real ones, not placeholders', () => {
   // The Anthropic data-flow disclosure is the reason this gate exists.
   assert.match(terms, /Anthropic/);
 });
+
+const os = require('node:os');
+const { loadLegal, needsAcceptance, acceptanceRecord } = require('../dist/main/legal.js');
+
+const MANIFEST = { version: '1.0', effective: '2026-07-26', summary: '' };
+
+function tempLegalDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memex-legal-'));
+  for (const [name, body] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), body);
+  return dir;
+}
+
+test('loadLegal reads the manifest and both documents', () => {
+  const dir = tempLegalDir({
+    'manifest.json': JSON.stringify({ version: '2.5', effective: '2027-01-01', summary: 'Clarified §4.' }),
+    'terms.md': '# Terms\nbody',
+    'privacy.md': '# Privacy\nbody',
+  });
+  const docs = loadLegal(dir);
+  assert.deepEqual(docs.manifest, { version: '2.5', effective: '2027-01-01', summary: 'Clarified §4.' });
+  assert.match(docs.terms, /# Terms/);
+  assert.match(docs.privacy, /# Privacy/);
+});
+
+test('loadLegal reads the real bundled documents', () => {
+  const docs = loadLegal(LEGAL_DIST);
+  assert.ok(docs);
+  assert.match(docs.terms, /Memex Desktop Terms of Use/);
+});
+
+test('loadLegal returns null when anything is missing or unusable', () => {
+  assert.equal(loadLegal(path.join(os.tmpdir(), 'memex-legal-does-not-exist')), null);
+  assert.equal(loadLegal(tempLegalDir({ 'manifest.json': '{ not json' })), null);
+  assert.equal(loadLegal(tempLegalDir({
+    'manifest.json': JSON.stringify({ version: '1.0' }),
+  })), null, 'a manifest without documents is unusable');
+  assert.equal(loadLegal(tempLegalDir({
+    'manifest.json': JSON.stringify({ effective: '2026-07-26' }),
+    'terms.md': 'x', 'privacy.md': 'x',
+  })), null, 'a manifest without a version is unusable');
+  assert.equal(loadLegal(tempLegalDir({
+    'manifest.json': JSON.stringify({ version: '1.0' }),
+    'terms.md': '   ', 'privacy.md': 'x',
+  })), null, 'an empty document is unusable');
+});
+
+test('needsAcceptance is true on a first run', () => {
+  assert.equal(needsAcceptance(undefined, MANIFEST), true);
+});
+
+test('needsAcceptance is false once the current version is accepted', () => {
+  assert.equal(needsAcceptance({ version: '1.0', acceptedAt: 'x', appVersion: '0.1.4' }, MANIFEST), false);
+});
+
+test('needsAcceptance is true when the terms version changed', () => {
+  assert.equal(needsAcceptance({ version: '1.0', acceptedAt: 'x', appVersion: '0.1.4' }, { ...MANIFEST, version: '1.1' }), true);
+  // Plain inequality, not a semver comparison: a rollback re-prompts too.
+  assert.equal(needsAcceptance({ version: '2.0', acceptedAt: 'x', appVersion: '0.9.0' }, MANIFEST), true);
+});
+
+test('needsAcceptance fails closed on a malformed record or missing manifest', () => {
+  assert.equal(needsAcceptance(null, MANIFEST), true);
+  assert.equal(needsAcceptance('1.0', MANIFEST), true);
+  assert.equal(needsAcceptance({}, MANIFEST), true);
+  assert.equal(needsAcceptance({ version: 42 }, MANIFEST), true);
+  assert.equal(needsAcceptance({ version: '  ' }, MANIFEST), true);
+  assert.equal(needsAcceptance({ version: '1.0' }, null), true, 'no manifest means show the gate');
+  assert.equal(needsAcceptance({ version: '1.0' }, { version: '', effective: '', summary: '' }), true);
+});
+
+test('acceptanceRecord stamps the version, time, and app version', () => {
+  const rec = acceptanceRecord(MANIFEST, '0.1.4', new Date('2026-07-26T12:00:00.000Z'));
+  assert.deepEqual(rec, { version: '1.0', acceptedAt: '2026-07-26T12:00:00.000Z', appVersion: '0.1.4' });
+  assert.equal(needsAcceptance(rec, MANIFEST), false, 'a fresh record satisfies the gate');
+});

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,6 +18,16 @@ pipeline without uploading anything, use the workflow's manual trigger
 App tags are prefixed `app-v` so desktop releases stay distinguishable from
 engine versioning (`VERSION`).
 
+## Before you tag: legal documents
+
+- **Legal documents:** if `app/legal/terms.md` or `app/legal/privacy.md` changed, bump
+  `version` and set `summary` in `app/legal/manifest.json` (this triggers the in-app
+  re-consent gate), and transcribe the same text into the matching per-product sections
+  on cytopixel.com. `version` and `effective` are the tell if the two drift.
+
+The terms version is deliberately independent of the app version — bump it only for
+substantive changes, since every bump re-prompts every existing user.
+
 ## What each platform needs
 
 | Platform | Signing | Status |

--- a/docs/superpowers/plans/2026-07-26-memex-eula-consent.md
+++ b/docs/superpowers/plans/2026-07-26-memex-eula-consent.md
@@ -1,0 +1,903 @@
+# Memex Terms-Acceptance Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate Memex Desktop behind a blocking Terms of Use / Privacy Notice acceptance screen on first launch and whenever the terms version changes, enforced in the main process.
+
+**Architecture:** The legal documents ship as markdown in `app/legal/`, copied into `dist/legal/` at build time and rendered to HTML in the main process. A pure, electron-free module (`src/main/legal.ts`) owns the accept/deny decision and fails closed. The main process refuses `vault:open` and `vault:create` while terms are unaccepted, so the overlay is the way to *satisfy* the check rather than the check itself. The overlay (`src/renderer/legal-gate.ts`) is a self-contained IIFE that also owns the vault-switcher link which reopens it read-only, so `renderer.ts` needs no knowledge of it.
+
+**Tech Stack:** TypeScript (strict) compiled by `tsc` only — no bundler. Electron 43 main/preload/renderer split. `marked` for markdown (already a dependency). Tests are `node:test` in CommonJS (`.cjs`) run against compiled `dist/`.
+
+## Global Constraints
+
+- **Design spec:** `docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md`. Read it before starting.
+- **No new dependencies.** Everything needed is already in `app/package.json`.
+- **The renderer is not a module.** `src/renderer/*.ts` and `src/shared/*.ts` compile as plain scripts (`moduleDetection: "legacy"`), loaded with bare `<script>` tags. No `import`/`export` in renderer files. All top-level names in those files share one global scope — wrap new renderer code in an IIFE to avoid collisions with `renderer.ts`.
+- **Shared types are ambient.** Add renderer-visible types to `src/shared/types.d.ts`, which has no imports/exports on purpose.
+- **`src/main/legal.ts` must not import electron.** Like `grants.ts` and `security.ts`, it takes paths and values as parameters. This is what makes it unit-testable.
+- **Fail closed.** A missing, unreadable, or unparseable manifest, or an acceptance record of the wrong shape, must show the gate. Re-reading terms is a nuisance; shipping an ungated build is not.
+- **Build scripts must be Windows-safe.** `scripts/copy-assets.js` exists because `mkdir -p && cp` broke the Windows build. Use `fs` calls only.
+- **Do not add any instruction telling users to `mkdir` a vault folder.** `tools/memex_init.py:318` already does `target.mkdir(parents=True, exist_ok=True)` and `main.ts:42` expands `~`. See Task 5.
+- **Copy strings are exact.** Where this plan gives user-facing text, use it verbatim.
+- **Terms version is independent of app version.** `app/legal/manifest.json` carries `version`; bump it only for substantive changes.
+
+---
+
+### Task 1: Bundle the legal documents into the build
+
+The documents already exist and are committed (`app/legal/terms.md`, `app/legal/privacy.md`, `app/legal/manifest.json`). They are not yet copied into `dist/`, so the main process cannot read them at runtime.
+
+**Files:**
+- Modify: `app/scripts/copy-assets.js`
+- Test: `app/test/legal.test.cjs` (created here, extended in Task 2)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `dist/legal/manifest.json`, `dist/legal/terms.md`, `dist/legal/privacy.md` — the directory `src/main/legal.ts` reads in Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/test/legal.test.cjs`:
+
+```js
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LEGAL_DIST = path.join(__dirname, '..', 'dist', 'legal');
+
+test('the build bundles the legal documents into dist/legal', () => {
+  for (const file of ['manifest.json', 'terms.md', 'privacy.md']) {
+    assert.ok(fs.existsSync(path.join(LEGAL_DIST, file)), `dist/legal/${file} must exist after a build`);
+  }
+});
+
+test('the bundled manifest declares a version and effective date', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(LEGAL_DIST, 'manifest.json'), 'utf8'));
+  assert.match(manifest.version, /^\d+\.\d+$/);
+  assert.match(manifest.effective, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(typeof manifest.summary, 'string');
+});
+
+test('the bundled documents are the real ones, not placeholders', () => {
+  const terms = fs.readFileSync(path.join(LEGAL_DIST, 'terms.md'), 'utf8');
+  const privacy = fs.readFileSync(path.join(LEGAL_DIST, 'privacy.md'), 'utf8');
+  assert.match(terms, /# Memex Desktop Terms of Use/);
+  assert.match(privacy, /# Memex Desktop Privacy Notice/);
+  // The Anthropic data-flow disclosure is the reason this gate exists.
+  assert.match(terms, /Anthropic/);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd app && npm run build && node --test test/legal.test.cjs`
+
+Expected: FAIL — `dist/legal/manifest.json must exist after a build`.
+
+- [ ] **Step 3: Copy the documents in the assets script**
+
+In `app/scripts/copy-assets.js`, append after the existing renderer copy loop:
+
+```js
+// The terms/privacy documents are read at runtime by src/main/legal.ts and shown in
+// the acceptance gate, so they have to land in dist/ like any other static asset.
+const legalSrc = path.join(__dirname, '..', 'legal');
+const legalDest = path.join(__dirname, '..', 'dist', 'legal');
+
+fs.mkdirSync(legalDest, { recursive: true });
+for (const file of ['manifest.json', 'terms.md', 'privacy.md']) {
+  fs.copyFileSync(path.join(legalSrc, file), path.join(legalDest, file));
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd app && npm run build && node --test test/legal.test.cjs`
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/scripts/copy-assets.js app/test/legal.test.cjs
+git commit -m "build: bundle the legal documents into dist/legal"
+```
+
+---
+
+### Task 2: The acceptance-decision module
+
+**Files:**
+- Create: `app/src/main/legal.ts`
+- Test: `app/test/legal.test.cjs` (extend)
+
+**Interfaces:**
+- Consumes: `dist/legal/` from Task 1.
+- Produces, all imported by `main.ts` in Task 3:
+  - `interface LegalManifest { version: string; effective: string; summary: string }`
+  - `interface LegalDocs { manifest: LegalManifest; terms: string; privacy: string }`
+  - `interface TermsAcceptance { version: string; acceptedAt: string; appVersion: string }`
+  - `loadLegal(dir: string): LegalDocs | null`
+  - `needsAcceptance(accepted: unknown, manifest: LegalManifest | null): boolean`
+  - `acceptanceRecord(manifest: LegalManifest, appVersion: string, now: Date): TermsAcceptance`
+
+> Naming note: the spec sketched this as `recordAcceptance(cfg, manifest)`. It is split
+> here into a pure `acceptanceRecord(…)` that builds the record and a config write that
+> stays in `main.ts`, which keeps `legal.ts` free of both `Date.now()` and config I/O and
+> so keeps it directly testable. Same behavior, better seam.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `app/test/legal.test.cjs`:
+
+```js
+const os = require('node:os');
+const { loadLegal, needsAcceptance, acceptanceRecord } = require('../dist/main/legal.js');
+
+const MANIFEST = { version: '1.0', effective: '2026-07-26', summary: '' };
+
+function tempLegalDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memex-legal-'));
+  for (const [name, body] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), body);
+  return dir;
+}
+
+test('loadLegal reads the manifest and both documents', () => {
+  const dir = tempLegalDir({
+    'manifest.json': JSON.stringify({ version: '2.5', effective: '2027-01-01', summary: 'Clarified §4.' }),
+    'terms.md': '# Terms\nbody',
+    'privacy.md': '# Privacy\nbody',
+  });
+  const docs = loadLegal(dir);
+  assert.deepEqual(docs.manifest, { version: '2.5', effective: '2027-01-01', summary: 'Clarified §4.' });
+  assert.match(docs.terms, /# Terms/);
+  assert.match(docs.privacy, /# Privacy/);
+});
+
+test('loadLegal reads the real bundled documents', () => {
+  const docs = loadLegal(LEGAL_DIST);
+  assert.ok(docs);
+  assert.match(docs.terms, /Memex Desktop Terms of Use/);
+});
+
+test('loadLegal returns null when anything is missing or unusable', () => {
+  assert.equal(loadLegal(path.join(os.tmpdir(), 'memex-legal-does-not-exist')), null);
+  assert.equal(loadLegal(tempLegalDir({ 'manifest.json': '{ not json' })), null);
+  assert.equal(loadLegal(tempLegalDir({
+    'manifest.json': JSON.stringify({ version: '1.0' }),
+  })), null, 'a manifest without documents is unusable');
+  assert.equal(loadLegal(tempLegalDir({
+    'manifest.json': JSON.stringify({ effective: '2026-07-26' }),
+    'terms.md': 'x', 'privacy.md': 'x',
+  })), null, 'a manifest without a version is unusable');
+  assert.equal(loadLegal(tempLegalDir({
+    'manifest.json': JSON.stringify({ version: '1.0' }),
+    'terms.md': '   ', 'privacy.md': 'x',
+  })), null, 'an empty document is unusable');
+});
+
+test('needsAcceptance is true on a first run', () => {
+  assert.equal(needsAcceptance(undefined, MANIFEST), true);
+});
+
+test('needsAcceptance is false once the current version is accepted', () => {
+  assert.equal(needsAcceptance({ version: '1.0', acceptedAt: 'x', appVersion: '0.1.4' }, MANIFEST), false);
+});
+
+test('needsAcceptance is true when the terms version changed', () => {
+  assert.equal(needsAcceptance({ version: '1.0', acceptedAt: 'x', appVersion: '0.1.4' }, { ...MANIFEST, version: '1.1' }), true);
+  // Plain inequality, not a semver comparison: a rollback re-prompts too.
+  assert.equal(needsAcceptance({ version: '2.0', acceptedAt: 'x', appVersion: '0.9.0' }, MANIFEST), true);
+});
+
+test('needsAcceptance fails closed on a malformed record or missing manifest', () => {
+  assert.equal(needsAcceptance(null, MANIFEST), true);
+  assert.equal(needsAcceptance('1.0', MANIFEST), true);
+  assert.equal(needsAcceptance({}, MANIFEST), true);
+  assert.equal(needsAcceptance({ version: 42 }, MANIFEST), true);
+  assert.equal(needsAcceptance({ version: '  ' }, MANIFEST), true);
+  assert.equal(needsAcceptance({ version: '1.0' }, null), true, 'no manifest means show the gate');
+  assert.equal(needsAcceptance({ version: '1.0' }, { version: '', effective: '', summary: '' }), true);
+});
+
+test('acceptanceRecord stamps the version, time, and app version', () => {
+  const rec = acceptanceRecord(MANIFEST, '0.1.4', new Date('2026-07-26T12:00:00.000Z'));
+  assert.deepEqual(rec, { version: '1.0', acceptedAt: '2026-07-26T12:00:00.000Z', appVersion: '0.1.4' });
+  assert.equal(needsAcceptance(rec, MANIFEST), false, 'a fresh record satisfies the gate');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd app && npm run build && node --test test/legal.test.cjs`
+
+Expected: FAIL — `Cannot find module '../dist/main/legal.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/src/main/legal.ts`:
+
+```ts
+// Terms-acceptance decision logic. Deliberately free of electron imports so the
+// whole decision surface is unit-testable: main.ts asks this module, and the gate
+// overlay in the renderer is only how the user satisfies the answer.
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface LegalManifest { version: string; effective: string; summary: string; }
+export interface LegalDocs { manifest: LegalManifest; terms: string; privacy: string; }
+export interface TermsAcceptance { version: string; acceptedAt: string; appVersion: string; }
+
+/** Reads a bundled legal directory. Returns null if anything is missing or unusable. */
+export function loadLegal(dir: string): LegalDocs | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(dir, 'manifest.json'), 'utf8')) as Partial<LegalManifest>;
+    const version = typeof raw.version === 'string' ? raw.version.trim() : '';
+    if (!version) return null;
+    const terms = fs.readFileSync(path.join(dir, 'terms.md'), 'utf8');
+    const privacy = fs.readFileSync(path.join(dir, 'privacy.md'), 'utf8');
+    if (!terms.trim() || !privacy.trim()) return null;
+    return {
+      manifest: {
+        version,
+        effective: typeof raw.effective === 'string' ? raw.effective : '',
+        summary: typeof raw.summary === 'string' ? raw.summary : '',
+      },
+      terms,
+      privacy,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Fails closed. A missing manifest, an unreadable document, or a record of the
+ * wrong shape all mean "show the gate": re-reading the terms is a nuisance,
+ * shipping a build that never shows them is not.
+ *
+ * Plain inequality rather than a semver comparison, so any declared-version
+ * change re-prompts — including a rollback.
+ */
+export function needsAcceptance(accepted: unknown, manifest: LegalManifest | null): boolean {
+  if (!manifest || !manifest.version) return true;
+  if (!accepted || typeof accepted !== 'object') return true;
+  const version = (accepted as { version?: unknown }).version;
+  if (typeof version !== 'string' || !version.trim()) return true;
+  return version !== manifest.version;
+}
+
+export function acceptanceRecord(manifest: LegalManifest, appVersion: string, now: Date): TermsAcceptance {
+  return { version: manifest.version, acceptedAt: now.toISOString(), appVersion: String(appVersion || '') };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd app && npm run build && node --test test/legal.test.cjs`
+
+Expected: PASS — 11 tests.
+
+- [ ] **Step 5: Run the whole suite and typecheck**
+
+Run: `cd app && npm test && npm run typecheck`
+
+Expected: all tests pass, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/legal.ts app/test/legal.test.cjs
+git commit -m "feat: add the terms-acceptance decision module"
+```
+
+---
+
+### Task 3: Main-process enforcement and IPC
+
+**Files:**
+- Modify: `app/src/main/main.ts` (imports near line 27; `PersistedConfig` line 38; `mdRenderer` line 56; `renderMarkdown` lines 160-169; IPC block from line 688; `vault:create` lines 742-745; `vault:open` lines 747-749)
+- Modify: `app/src/shared/types.d.ts` (add `LegalState`, extend `MemexApi`)
+- Modify: `app/src/preload/preload.ts` (three bridge methods)
+
+**Interfaces:**
+- Consumes: `loadLegal`, `needsAcceptance`, `acceptanceRecord`, `TermsAcceptance` from Task 2.
+- Produces, all used by Task 4:
+  - `interface LegalState { needsAcceptance: boolean; version: string; effective: string; summary: string; terms: string; privacy: string }` — `terms` and `privacy` are **rendered HTML**, not markdown.
+  - `window.memex.legalState(): Promise<LegalState>`
+  - `window.memex.legalAccept(): Promise<{ ok: boolean }>`
+  - `window.memex.legalQuit(): Promise<void>`
+
+- [ ] **Step 1: Add the shared types**
+
+In `app/src/shared/types.d.ts`, add after the `CreateVaultResult` line (~line 134):
+
+```ts
+// Terms/privacy state for the acceptance gate. `terms` and `privacy` are HTML
+// rendered by the main process, not markdown.
+interface LegalState {
+  needsAcceptance: boolean;
+  version: string;
+  effective: string;
+  summary: string;
+  terms: string;
+  privacy: string;
+}
+```
+
+And in `interface MemexApi`, after `appVersion(): Promise<string>;`:
+
+```ts
+  legalState(): Promise<LegalState>;
+  legalAccept(): Promise<{ ok: boolean }>;
+  legalQuit(): Promise<void>;
+```
+
+- [ ] **Step 2: Add the preload bridge methods**
+
+In `app/src/preload/preload.ts`, after the `appVersion` line in the `// vault lifecycle` group:
+
+```ts
+  legalState: () => invoke('legal:state'),
+  legalAccept: () => invoke('legal:accept'),
+  legalQuit: () => invoke('app:quit'),
+```
+
+- [ ] **Step 3: Wire the module into main.ts**
+
+Add to the import block after line 27 (`import { unpackedClaudeBinaryPath } from './claude-binary';`):
+
+```ts
+import { acceptanceRecord, loadLegal, needsAcceptance, type LegalDocs, type TermsAcceptance } from './legal';
+```
+
+Add after the `RENDERER_PATH` / `CONFIG_PATH` constants (line 36):
+
+```ts
+const LEGAL_DIR = path.join(__dirname, '..', 'legal');
+```
+
+Change `PersistedConfig` (line 38) to carry the acceptance record:
+
+```ts
+interface PersistedConfig extends ToolGrantState { recent?: string[]; last?: string; terms?: TermsAcceptance; }
+```
+
+Add after `let mdRenderer: ((md: string) => string) | null = null;` (line 56):
+
+```ts
+// `undefined` = not yet read, `null` = read and unusable. Cached because the
+// documents cannot change without a new build.
+let legalDocs: LegalDocs | null | undefined;
+function legal(): LegalDocs | null {
+  if (legalDocs === undefined) legalDocs = loadLegal(LEGAL_DIR);
+  return legalDocs;
+}
+// The gate is enforced here, not in the renderer: MEMEX_OPEN and any UI bug
+// would otherwise sail straight past a purely visual overlay.
+function termsAccepted(): boolean {
+  return !needsAcceptance(loadConfig().terms, legal()?.manifest || null);
+}
+```
+
+- [ ] **Step 4: Split the markdown renderer so legal text skips the wikilink pass**
+
+Replace `renderMarkdown` (lines 160-169) with:
+
+```ts
+async function ensureMarkdownRenderer(): Promise<(md: string) => string> {
+  if (!mdRenderer) {
+    const { marked, Renderer } = await import('marked');
+    const renderer = new Renderer();
+    hardenMarkdownRenderer(renderer);
+    marked.setOptions({ breaks: true, gfm: true, renderer });
+    mdRenderer = (s: string) => marked.parse(s) as string;
+  }
+  return mdRenderer;
+}
+
+async function renderMarkdown(md: string): Promise<string> {
+  const render = await ensureMarkdownRenderer();
+  return render(await linkifyWikilinks(md || ''));
+}
+
+// Legal documents contain no wikilinks and are shown before any vault is open,
+// so they skip the vault-scoped wikilink pass entirely.
+async function renderPlainMarkdown(md: string): Promise<string> {
+  const render = await ensureMarkdownRenderer();
+  return render(md || '');
+}
+```
+
+- [ ] **Step 5: Add the IPC handlers**
+
+Inside `registerIpc()`, after the `handle('vault:pick', …)` block (line 700):
+
+```ts
+  handle('legal:state', async (): Promise<LegalState> => {
+    const docs = legal();
+    if (!docs) {
+      // Fail closed and say so, rather than silently letting the user through.
+      return {
+        needsAcceptance: true, version: '', effective: '', summary: '',
+        terms: '<p>The Terms of Use could not be loaded, so Memex cannot continue. Please reinstall the app.</p>',
+        privacy: '<p>The Privacy Notice could not be loaded, so Memex cannot continue. Please reinstall the app.</p>',
+      };
+    }
+    const cfg = loadConfig();
+    return {
+      needsAcceptance: needsAcceptance(cfg.terms, docs.manifest),
+      version: docs.manifest.version,
+      effective: docs.manifest.effective,
+      // "What changed" is meaningless on a first run — only show it to someone
+      // who accepted an earlier version.
+      summary: cfg.terms ? docs.manifest.summary : '',
+      terms: await renderPlainMarkdown(docs.terms),
+      privacy: await renderPlainMarkdown(docs.privacy),
+    };
+  });
+
+  handle('legal:accept', async () => {
+    const docs = legal();
+    if (!docs) return { ok: false };
+    const cfg = loadConfig();
+    cfg.terms = acceptanceRecord(docs.manifest, app.getVersion(), new Date());
+    saveConfig(cfg);
+    return { ok: true };
+  });
+
+  handle('app:quit', async () => { app.quit(); });
+```
+
+- [ ] **Step 6: Refuse to open or create a vault while terms are unaccepted**
+
+Replace the `vault:create` handler (lines 742-745):
+
+```ts
+  handle('vault:create', async (_e, opts: { target: string; answers: Record<string, string>; packs: string }) => {
+    if (!termsAccepted()) return { ok: false, code: -1, output: 'Please accept the Terms of Use to continue.' };
+    const res = await createVault({ ...opts, target: expandHome(opts.target) });
+    return res;
+  });
+```
+
+In the `vault:open` handler, add as the first line of the body (before `const full = expandHome(p);` at line 748):
+
+```ts
+    if (!termsAccepted()) return { ok: false, error: 'Please accept the Terms of Use to continue' };
+```
+
+- [ ] **Step 7: Verify it compiles and nothing regressed**
+
+Run: `cd app && npm run typecheck && npm test`
+
+Expected: no type errors; all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/main.ts app/src/shared/types.d.ts app/src/preload/preload.ts
+git commit -m "feat: enforce terms acceptance in the main process"
+```
+
+---
+
+### Task 4: The acceptance gate overlay
+
+**Files:**
+- Create: `app/src/renderer/legal-gate.ts`
+- Modify: `app/src/renderer/index.html` (gate markup after the `.onboard` block ending line 182; review link inside `.onboard-inner`; script tag)
+- Modify: `app/src/renderer/styles.css` (append a gate section)
+
+**Interfaces:**
+- Consumes: `window.memex.legalState()`, `legalAccept()`, `legalQuit()`, and the `LegalState` type from Task 3.
+- Produces: nothing consumed by later tasks. The overlay is self-contained — it owns its DOM, its wiring, and the `#legalReview` link. `renderer.ts` is not modified in this task.
+
+- [ ] **Step 1: Add the gate markup**
+
+In `app/src/renderer/index.html`, insert the review link inside `.onboard-inner`, immediately after the `#resetApprovals` button (line 179):
+
+```html
+      <button class="legal-link" id="legalReview" type="button">Terms of Use · Privacy</button>
+```
+
+Then insert this block after the closing `</div>` of the `.onboard` overlay (after line 182, before the `<script>` tags):
+
+```html
+  <!-- ======================= TERMS GATE ======================= -->
+  <div class="legal" id="legalGate" style="display:none">
+    <div class="legal-inner">
+      <div class="legal-head">
+        <div class="wordmark big"><span class="mark">Memex</span></div>
+        <h2 class="legal-title">Before you start</h2>
+        <p class="legal-eff" id="legalEffective"></p>
+        <p class="legal-changed" id="legalChanged" style="display:none"></p>
+      </div>
+
+      <div class="legal-tabs">
+        <button class="legal-tab active" id="legalTabTerms" type="button">Terms of Use</button>
+        <button class="legal-tab" id="legalTabPrivacy" type="button">Privacy Notice</button>
+      </div>
+
+      <div class="legal-doc" id="legalDoc"></div>
+
+      <p class="legal-online">
+        Also published at
+        <a href="https://cytopixel.com/terms-of-service/">cytopixel.com/terms-of-service</a> and
+        <a href="https://cytopixel.com/privacy-policy/">cytopixel.com/privacy-policy</a>.
+      </p>
+
+      <div class="legal-foot">
+        <div id="legalConsent">
+          <label class="legal-agree">
+            <input type="checkbox" id="legalAgree" />
+            <span>I have read and agree to the Memex Terms of Use and Privacy Notice.</span>
+          </label>
+          <div class="legal-actions">
+            <button class="btn ghost" id="legalDecline" type="button">Decline and quit</button>
+            <button class="btn primary" id="legalAcceptBtn" type="button" disabled>Agree and continue</button>
+          </div>
+        </div>
+        <button class="btn ghost legal-close" id="legalClose" type="button" style="display:none">Close</button>
+      </div>
+    </div>
+  </div>
+```
+
+Add the script tag as the **last** script, after `renderer.js` (line 186):
+
+```html
+  <script src="legal-gate.js"></script>
+```
+
+- [ ] **Step 2: Add the styles**
+
+Append to `app/src/renderer/styles.css`:
+
+```css
+/* ======================= TERMS GATE ======================= */
+/* Above .onboard (z-index 20): the gate must cover the vault switcher too. */
+.legal { position: fixed; inset: 0; z-index: 40; background: radial-gradient(ellipse at 30% 0%, var(--bg-2), var(--bg)); display: grid; place-items: center; overflow: auto; }
+.legal-inner { width: min(760px, 92vw); padding: 34px 0; }
+.legal-head { text-align: center; margin-bottom: 20px; }
+.legal-title { font-family: var(--font-display); font-size: 24px; font-weight: 600; color: var(--ink); margin: 14px 0 6px; }
+.legal-eff { font-size: 12px; color: var(--ink-faint); margin: 0; }
+.legal-changed { font-size: 13px; line-height: 1.6; color: var(--ink-dim); max-width: 520px; margin: 12px auto 0; }
+.legal-tabs { display: flex; gap: 8px; margin-bottom: 12px; }
+.legal-tab { padding: 7px 14px; border: 1px solid var(--line); border-radius: 20px; background: transparent; color: var(--ink-dim); font: 12.5px var(--font-ui); cursor: pointer; }
+.legal-tab.active { border-color: var(--accent); background: var(--accent-soft); color: var(--ink); }
+.legal-doc {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
+  padding: 20px 26px; max-height: 46vh; overflow: auto;
+  font-size: 13px; line-height: 1.7; color: var(--ink-dim);
+}
+.legal-doc h1 { font-family: var(--font-display); font-size: 20px; color: var(--ink); margin: 0 0 10px; }
+.legal-doc h2 { font-size: 14px; color: var(--ink); margin: 22px 0 8px; }
+.legal-doc h3 { font-size: 13px; color: var(--ink); margin: 16px 0 6px; }
+.legal-doc p, .legal-doc li { margin: 8px 0; }
+.legal-doc ul, .legal-doc ol { padding-left: 22px; }
+.legal-doc strong { color: var(--ink); }
+.legal-doc a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
+.legal-doc hr { border: none; border-top: 1px solid var(--line); margin: 20px 0; }
+/* Plain <a href>: renderer.ts's document-level click handler already delegates
+   http(s) links to the system browser, so these need no wiring of their own. */
+.legal-online { font-size: 11.5px; color: var(--ink-faint); margin: 10px 0 0; text-align: center; }
+.legal-online a { color: var(--ink-dim); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
+.legal-foot { margin-top: 18px; }
+.legal-agree { display: flex; align-items: flex-start; gap: 9px; font-size: 13px; line-height: 1.5; color: var(--ink-dim); cursor: pointer; }
+.legal-agree input { margin-top: 2px; }
+.legal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px; }
+.legal-close { display: block; margin: 0 auto; }
+.legal-link { display: block; margin: 9px auto 0; padding: 2px 4px; border: 0; background: transparent; color: var(--ink-faint); font: 11px var(--font-ui); text-decoration: underline; cursor: pointer; }
+.legal-link:hover { color: var(--ink-dim); }
+```
+
+- [ ] **Step 3: Write the gate script**
+
+Create `app/src/renderer/legal-gate.ts`:
+
+```ts
+// The terms-acceptance gate. Compiled as a plain (non-module) script like
+// renderer.ts, so everything lives inside one IIFE: top-level names in these
+// files share a single global scope, and `$`/`el`/`M` are already taken.
+//
+// Self-contained on purpose — it owns its markup, its wiring, and the
+// vault-switcher link that reopens it read-only, so renderer.ts needs to know
+// nothing about it. Enforcement is in the main process (vault:open and
+// vault:create refuse until terms are accepted); this overlay is only how the
+// user satisfies that check.
+(() => {
+  const api = window.memex;
+  const id = (name: string): HTMLElement => document.getElementById(name) as HTMLElement;
+
+  const gate = id('legalGate');
+  const docPane = id('legalDoc');
+  const agree = id('legalAgree') as HTMLInputElement;
+  const acceptBtn = id('legalAcceptBtn') as HTMLButtonElement;
+  const closeBtn = id('legalClose') as HTMLButtonElement;
+  const tabTerms = id('legalTabTerms');
+  const tabPrivacy = id('legalTabPrivacy');
+
+  let rendered = { terms: '', privacy: '' };
+
+  // The documents are HTML rendered by the main process through the hardened
+  // marked renderer, which strips raw HTML and admits only vetted links.
+  const showDoc = (which: 'terms' | 'privacy'): void => {
+    docPane.innerHTML = which === 'terms' ? rendered.terms : rendered.privacy;
+    docPane.scrollTop = 0;
+    tabTerms.classList.toggle('active', which === 'terms');
+    tabPrivacy.classList.toggle('active', which === 'privacy');
+  };
+
+  const open = (mode: 'gate' | 'review', state: LegalState): void => {
+    rendered = { terms: state.terms, privacy: state.privacy };
+    id('legalEffective').textContent = state.version
+      ? `Version ${state.version}${state.effective ? ` · effective ${state.effective}` : ''}`
+      : '';
+
+    // "What changed" only helps someone who accepted an earlier version; the
+    // main process leaves `summary` empty on a first run.
+    const changed = id('legalChanged');
+    const showChanged = mode === 'gate' && !!state.summary;
+    changed.textContent = showChanged ? `What changed: ${state.summary}` : '';
+    changed.style.display = showChanged ? '' : 'none';
+
+    agree.checked = false;
+    acceptBtn.disabled = true;
+    id('legalConsent').style.display = mode === 'gate' ? '' : 'none';
+    closeBtn.style.display = mode === 'gate' ? 'none' : '';
+
+    showDoc('terms');
+    gate.style.display = 'grid';
+    // Keep focus and screen readers inside the gate while it is up.
+    id('workspace').inert = true;
+    id('onboard').inert = true;
+    (mode === 'gate' ? agree : closeBtn).focus();
+  };
+
+  const close = (): void => {
+    gate.style.display = 'none';
+    id('workspace').inert = false;
+    id('onboard').inert = false;
+  };
+
+  tabTerms.onclick = () => showDoc('terms');
+  tabPrivacy.onclick = () => showDoc('privacy');
+  agree.onchange = () => { acceptBtn.disabled = !agree.checked; };
+
+  acceptBtn.onclick = async () => {
+    acceptBtn.disabled = true;
+    const res = await api.legalAccept();
+    if (res.ok) { close(); return; }
+    // Recording failed, which means the documents are unreadable. Do not let the
+    // user through — the main process would refuse to open a vault anyway — and
+    // say why instead of leaving a dead button.
+    agree.checked = false;
+    const changed = id('legalChanged');
+    changed.textContent = 'Memex could not record your acceptance. Please reinstall the app.';
+    changed.style.display = '';
+  };
+
+  id('legalDecline').onclick = () => { void api.legalQuit(); };
+  closeBtn.onclick = close;
+  id('legalReview').onclick = async () => { open('review', await api.legalState()); };
+
+  void (async () => {
+    const state = await api.legalState();
+    if (state.needsAcceptance) open('gate', state);
+  })();
+})();
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd app && npm run typecheck && npm run build`
+
+Expected: no errors, and `dist/renderer/legal-gate.js` exists.
+
+- [ ] **Step 5: Drive the gate in the real app**
+
+Capture the userData directory rather than guessing it — it differs between dev and
+packaged builds (dev uses the `name` from `package.json`, a packaged build uses the
+`build.productName`):
+
+```bash
+cd app
+CFG="$(npx electron -e "const {app}=require('electron');app.whenReady().then(()=>{console.log(app.getPath('userData'));app.quit()})" | tail -1)/config.json"
+echo "$CFG"
+```
+
+Move the config aside to simulate a first run, then launch:
+
+```bash
+[ -f "$CFG" ] && mv "$CFG" "$CFG.bak"
+npm start
+```
+
+Confirm by observation:
+1. The gate appears over the vault switcher on launch.
+2. "Agree and continue" is disabled until the checkbox is ticked.
+3. The Privacy Notice tab switches documents; an Anthropic link opens in the system browser.
+4. Accepting dismisses the gate and reveals the vault switcher.
+5. Relaunching (`npm start`) shows no gate.
+6. `grep terms "<userData>/config.json"` shows the recorded version, timestamp, and app version.
+7. The "Terms of Use · Privacy" link in the switcher footer reopens the overlay with a Close button and no checkbox.
+
+Then restore your config: `mv "$CFG.bak" "$CFG"` (if you moved one aside).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/renderer/legal-gate.ts app/src/renderer/index.html app/src/renderer/styles.css
+git commit -m "feat: add the terms acceptance gate overlay"
+```
+
+---
+
+### Task 5: Folder-creation clarity and publisher email
+
+Part C of the spec. A user was told to `mkdir` their vault folder in Terminal before starting. That step is not required — `tools/memex_init.py:318` mkdirs parents and `main.ts:42` expands `~`. The fix is copy that says so. **Do not add the mkdir instruction.**
+
+**Files:**
+- Modify: `app/src/renderer/index.html` (Location field, lines 160-165)
+- Modify: `app/src/renderer/styles.css` (one rule)
+- Modify: `app/src/renderer/renderer.ts:84` (flash copy)
+- Modify: `app/package.json` (author email)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the hint under the Location field**
+
+In `app/src/renderer/index.html`, replace the Location label (lines 160-165) with:
+
+```html
+            <label>Location
+              <div class="path-row">
+                <input id="f_path" placeholder="~/code/my-vault" required />
+                <button type="button" class="btn tiny" id="pickPath">…</button>
+              </div>
+              <span class="field-hint">Doesn't exist yet? Memex creates it for you, including parent folders.</span>
+            </label>
+```
+
+- [ ] **Step 2: Style the hint**
+
+Append to `app/src/renderer/styles.css`:
+
+```css
+.field-hint { font-size: 11.5px; line-height: 1.5; color: var(--ink-faint); }
+```
+
+- [ ] **Step 3: Reword the non-vault flash**
+
+In `app/src/renderer/renderer.ts`, replace line 84:
+
+```ts
+  else { ($('f_path') as HTMLInputElement).value = p; flash('That folder isn\'t a Memex vault yet. The form on the right can set one up there, or pick another folder.'); }
+```
+
+- [ ] **Step 4: Update the publisher email**
+
+In `app/package.json`, change the author email:
+
+```json
+  "author": {
+    "name": "Arjun Raj",
+    "email": "araj@cytopixel.com"
+  },
+```
+
+Leave `"license": "MIT"` and the author name unchanged — see the spec's "License choice: MIT retained".
+
+- [ ] **Step 5: Verify the behavior the new copy promises**
+
+Run: `cd app && npm run build && npm start`
+
+In the create form, enter a Location whose parent does not exist (for example `~/memex-parent-check/v1`), fill name and email, and click Create vault. Confirm it succeeds with no prior `mkdir`, then clean up:
+
+```bash
+rm -rf ~/memex-parent-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/renderer/index.html app/src/renderer/styles.css app/src/renderer/renderer.ts app/package.json
+git commit -m "fix: say that Memex creates the vault folder; update publisher email"
+```
+
+---
+
+### Task 6: Full verification, including a packaged build
+
+`app/README.md` and `docs/RELEASING.md` are emphatic that `npm start` does not exercise packaged asset paths, and this change adds new bundled files that must land correctly in the built app. This has bitten the project three times.
+
+**Files:** none modified — this task is verification, plus a `docs/RELEASING.md` note.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: a verified build.
+
+- [ ] **Step 1: Full local suite**
+
+Run: `cd app && npm test && npm run typecheck`
+
+Expected: all tests pass, no type errors.
+
+- [ ] **Step 2: Verify re-consent on a version bump**
+
+Bump the terms version and add a summary:
+
+```bash
+cd app && node -e "
+const fs=require('fs'),p='legal/manifest.json';
+const m=JSON.parse(fs.readFileSync(p,'utf8'));
+fs.writeFileSync(p,JSON.stringify({...m,version:'1.1',summary:'Test bump — clarified the Anthropic disclosure.'},null,2)+'\n');
+"
+npm start
+```
+
+Confirm the gate reappears for an already-accepted user, and that "What changed: Test bump — clarified the Anthropic disclosure." shows above the documents.
+
+Then revert the bump:
+
+```bash
+cd app && git checkout legal/manifest.json
+```
+
+- [ ] **Step 3: Verify decline quits**
+
+Move the config aside as in Task 4 Step 5, run `npm start`, and click "Decline and quit". Confirm the app exits and that no `terms` key was written to `config.json`. Restore the config.
+
+- [ ] **Step 4: Verify the packaged build**
+
+```bash
+cd app && npm run pack
+```
+
+Then confirm the documents are inside the bundle:
+
+```bash
+npx asar list "release/mac-arm64/Memex.app/Contents/Resources/app.asar" | grep legal
+```
+
+Expected: `/dist/legal/manifest.json`, `/dist/legal/terms.md`, `/dist/legal/privacy.md`.
+
+(Adjust the path for your platform's output directory. On a first packaged run the userData directory differs from dev, so the gate should appear even if you already accepted in dev — that is correct behavior and confirms the record is per-install-target.)
+
+Launch the packaged app and confirm the gate renders with real document text, not the "could not be loaded" fallback. That fallback appearing in a packaged build but not in dev is exactly the class of failure this step exists to catch.
+
+- [ ] **Step 5: Note the two-repo sync requirement**
+
+Add to `docs/RELEASING.md`, in the release checklist:
+
+```markdown
+- **Legal documents:** if `app/legal/terms.md` or `app/legal/privacy.md` changed, bump
+  `version` and set `summary` in `app/legal/manifest.json` (this triggers the in-app
+  re-consent gate), and transcribe the same text into the matching per-product sections
+  on cytopixel.com. `version` and `effective` are the tell if the two drift.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/RELEASING.md
+git commit -m "docs: note the legal-document release checklist"
+```
+
+---
+
+## Second deliverable: the website sections
+
+Tracked separately because it lives in another repository (`../cytopixel_website`, `github.com/CytoPixel/cytopixel_website`), and it is publication rather than code.
+
+- [ ] Transcribe `app/legal/terms.md` into a new per-product section of `terms-of-service/index.html`, alongside the existing "CytoPixel NimbusImage Terms of Service" section, matching that page's existing markup and `.legal-*` classes.
+- [ ] Transcribe `app/legal/privacy.md` into `privacy-policy/index.html` the same way.
+- [ ] Keep the version and effective date identical to `app/legal/manifest.json`.
+- [ ] Open as a separate pull request in that repository.
+
+**Do not publish before counsel review.** The spec's "Remaining open item" flags two clauses specifically: the MIT carve-out in Terms §2, and the HIPAA framing in §7(a).

--- a/docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md
+++ b/docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md
@@ -1,0 +1,277 @@
+# Memex Desktop — terms acceptance (EULA) design
+
+**Date:** 2026-07-26
+**Status:** approved design, not yet implemented
+**Scope:** two new legal documents published by CytoPixel Software LLC, plus a blocking
+in-app acceptance gate in the Memex desktop app.
+
+## Why
+
+Memex is shipping as a general-purpose assistant that reads and writes a folder of the
+user's notes and sends their contents to a third-party AI provider. Before launch it needs
+a document that (a) discloses that data flow, (b) disclaims warranty and liability, and
+(c) prohibits categories of data that must not be handed to a third-party AI provider.
+Nothing in the app collects or transmits data to CytoPixel — the point of the document is
+disclosure and allocation of risk, not a data-collection notice.
+
+The existing `cytopixel_website` policies do **not** cover this. Both are titled
+"CytoPixel NimbusImage Terms of Service / Privacy Policy" and describe a SaaS product with
+accounts, server-side image uploads, subscription fees, and AWS hosting. Pointing Memex
+users at them would have users agreeing to terms about a product they aren't using. The
+terms page is already structured as "Per-product Terms of Service", so Memex slots in as a
+sibling section.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Licensor | CytoPixel Software LLC | Same entity and site as NimbusImage; an LLC absorbs liability, an individual doesn't. |
+| Where documents live | New per-product sections on cytopixel.com | Canonical public copy; matches the existing per-product structure. |
+| In-app text source | Bundled in the build, versioned | Works offline (launch is network-free today), renders instantly, and pins the exact text a user accepted to the version they installed. |
+| Gate behavior | Blocking on first launch and on every terms-version bump | Terms carry their own version, bumped only for substantive change, so typo fixes don't re-prompt. One code path. |
+| Sensitive-data posture | Hard prohibition on PHI / regulated data / clinical reliance | Chosen deliberately for the strongest shield. |
+| Research-use-only clause | **Not** included | NimbusImage's "internal research purposes" restriction would bar someone from tracking personal errands in a personal-notes app. CytoPixel never receives or stores vault data, so the narrow PHI prohibition carries the weight on its own. |
+| Governing law | Delaware, exclusive Delaware venue | Mirrors the NimbusImage terms verbatim. |
+| Contact | support@cytopixel.com | Same as NimbusImage. |
+
+## Verified facts these documents rest on
+
+Established by reading the code, not assumed:
+
+- **No telemetry of any kind.** The app makes exactly two categories of outbound request:
+  `autoUpdater.checkForUpdatesAndNotify()` to GitHub releases (`app/src/main/main.ts:548`),
+  and Agent SDK traffic to Anthropic under the user's own credentials. No analytics, no
+  crash reporting. "CytoPixel collects nothing" is literally true.
+- **Local state** lives in `config.json` under `app.getPath('userData')`
+  (`app/src/main/main.ts:36`): recent vault paths, `last`, and per-vault tool grants.
+- **The packaged app redistributes proprietary Anthropic software.**
+  `@anthropic-ai/claude-agent-sdk` declares `license: "SEE LICENSE IN README.md"`, and its
+  `LICENSE.md` reads "© Anthropic PBC. All rights reserved. Use is subject to the Legal
+  Agreements outlined here: https://code.claude.com/docs/en/legal-and-compliance". The
+  platform sibling `@anthropic-ai/claude-agent-sdk-<platform>-<arch>` carries the same
+  posture and contains the `claude` executable the app spawns from `app.asar.unpacked`
+  (`app/src/main/claude-binary.ts:9`). So `app/package.json`'s `"license": "MIT"` describes
+  the source, not the shipped artifact.
+- **MIT with an outside contributor.** `LICENSE` is MIT, copyright "Memex Engine
+  contributors"; git history shows one commit from `Andrew Su <asu@scripps.edu>`.
+- **Anthropic covers PHI only under a BAA with Zero Data Retention enabled**
+  (Anthropic legal-and-compliance page), which gives the PHI prohibition a precise reason.
+
+## Open items — launch-gating, not resolved by this design
+
+These are business/legal questions this document cannot settle. They are recorded here so
+they don't get lost, and they do not block implementation of the gate.
+
+1. **Redistribution of the bundled Claude CLI.** Anthropic's legal-and-compliance page is
+   silent on redistribution, embedding, or bundling; `LICENSE.md` says "All rights
+   reserved", so no redistribution right is granted by default. Shipping the `claude`
+   binary inside a third-party DMG/installer needs express permission or a different
+   packaging approach.
+2. **The OAuth credential model.** Anthropic's page states that OAuth auth "is intended
+   exclusively for purchasers of Claude Free, Pro, Max, Team, and Enterprise subscription
+   plans and is designed to support ordinary use of Claude Code and other native Anthropic
+   applications", that Agent SDK developers "should use API key authentication", and that
+   "Anthropic does not permit third-party developers to offer Claude.ai login or to route
+   requests through Free, Pro, or Max plan credentials on behalf of their users" —
+   reserving enforcement "without prior notice". Memex's documented auth model ("Auth
+   comes from your logged-in Claude Code CLI (no API key needed)") is squarely in that
+   territory. Arguments that Memex is on the right side: it routes nothing through
+   CytoPixel servers, does not implement Claude.ai login itself, and each user's
+   credentials are used on their own machine for their own benefit — close to "ordinary,
+   individual usage". **Action: raise with Anthropic (sales/support) in parallel with
+   launch.** An EULA cannot resolve this; CytoPixel's own terms grant CytoPixel no rights
+   against Anthropic.
+3. **Counsel review** of both drafted documents before publication.
+
+Decision on record: proceed with the gate as designed, disclose the auth relationship in
+the terms, and pursue (1) and (2) with Anthropic in parallel.
+
+## Part A — the documents
+
+Both are new per-product sections on cytopixel.com, licensor CytoPixel Software LLC,
+Delaware law, mirroring the NimbusImage structure and tone.
+
+### A1. Memex Desktop Terms of Use
+
+1. **What Memex is.** Software the user installs and runs locally. No hosted service, no
+   accounts, no CytoPixel servers. Deliberately *not* the SaaS framing NimbusImage uses.
+2. **License grant.** Free, non-exclusive, non-transferable right to install and use the
+   packaged application. States explicitly that the source is separately available under
+   the MIT License and that these terms govern the *distributed binary* without reducing
+   MIT rights in the source.
+   **Ownership language must not be copied from NimbusImage.** Its "CytoPixel retains all
+   right, title, and interest in and to the Program" is false here (MIT, outside
+   contributor, copyright held by "Memex Engine contributors"). Instead: CytoPixel and its
+   licensors retain ownership of their respective contributions, and nothing in these terms
+   limits rights granted by the MIT License in the source.
+3. **Trademark reservation.** MIT grants no trademark rights, so the "Memex" and
+   "CytoPixel" names and logos are reserved separately. This is the one restriction in the
+   document that MIT does not undercut.
+4. **Third-party AI services.** The core disclosure. Memex operates by sending the user's
+   prompts and the contents of files in their vault to Anthropic, PBC through the user's
+   *own* Claude account. The user's agreement with Anthropic and Anthropic's privacy and
+   usage policies govern that data, including retention and any use Anthropic permits
+   itself. CytoPixel is not a party to that agreement, receives none of that data, and
+   cannot access, control, or delete it.
+5. **Third-party components.** The application includes software licensed by Anthropic PBC
+   (the Claude Agent SDK and the bundled `claude` CLI), whose use is subject to Anthropic's
+   Commercial Terms (Team, Enterprise, API) or Consumer Terms of Service (Free, Pro, Max)
+   and the Anthropic Usage Policy, with links. The user is responsible for holding an
+   Anthropic account in good standing and for using an authentication method Anthropic
+   permits for their plan. The document must not instruct users toward any authentication
+   method Anthropic disallows.
+6. **Agentic operation.** The user acknowledges the software autonomously creates,
+   modifies, moves, and deletes files in the vault directory and can execute commands the
+   user approves; output may be inaccurate; the user is responsible for reviewing its
+   actions and maintaining backups; output is not medical, legal, or financial advice.
+7. **Prohibited data and uses.** No HIPAA PHI; no identifiable patient or research-subject
+   data; no clinical or diagnostic reliance; no data whose disclosure to a third-party AI
+   provider would breach law, contract, IRB protocol, FERPA, export control, or a
+   confidentiality obligation; no unlawful use; no circumventing Anthropic's usage
+   policies. Cite the reason: Anthropic covers PHI only where the user's own organization
+   holds a BAA with Zero Data Retention enabled, which an individual Memex user will not
+   have.
+8. **Updates.** The application checks GitHub for updates and may download and install
+   them.
+9. **Disclaimer of warranties** — AS IS / AS AVAILABLE, mirroring NimbusImage §7.
+10. **Limitation of liability** with cap, mirroring NimbusImage §8.
+11. **Indemnification**, mirroring NimbusImage §9 minus the upload-specific clause.
+12. **Term and termination.** Stop using and uninstall; no fees to unwind.
+13. **Changes to these terms.** A new version is presented in the application; continued
+    use requires acceptance; a user who declines should discontinue use.
+14. **Governing law and jurisdiction** — Delaware, exclusive Delaware venue, UN CISG
+    excluded, mirroring NimbusImage §13.
+15. **Contact** — support@cytopixel.com.
+
+### A2. Memex Privacy Notice
+
+Short, and its headline is genuinely "we collect nothing":
+
+- CytoPixel operates no servers for Memex and collects **no** personal information,
+  telemetry, analytics, or crash reports. The vault never touches CytoPixel
+  infrastructure.
+- **What leaves the device, and to whom:** Anthropic (prompts and vault content, under the
+  user's own account, governed by Anthropic); GitHub (update checks expose IP and
+  user-agent to GitHub); and anything the user explicitly opens — external links handed to
+  the system browser, `kind: "web"` tabs they configure, MCP connectors they enable in
+  their own Claude account.
+- **Stored locally, never transmitted:** `config.json` in the OS app-data directory —
+  recent vault paths, per-vault tool approvals, and the terms-acceptance record.
+- No cookies (this is not a website), no data sales, children's use, contact.
+
+## Part B — the app
+
+### B1. Enforcement lives in the main process
+
+A renderer-only overlay would be cosmetic and bypassable — note `MEMEX_OPEN=/path` already
+auto-opens a vault at launch, sailing past anything purely visual. The check therefore sits
+at the one chokepoint where anything meaningful begins: the `vault:open` and `vault:create`
+IPC handlers refuse while terms are unaccepted. The overlay is the UI for satisfying that
+check, not the check itself.
+
+### B2. New module: `app/src/main/legal.ts` (~60 lines)
+
+The entire decision surface, kept small and directly testable:
+
+- `loadLegal()` — reads `dist/legal/manifest.json` and the two markdown documents.
+- `needsAcceptance(cfg, manifest)` — `!cfg.terms || cfg.terms.version !== manifest.version`.
+  Plain inequality rather than a semver comparison, so any declared-version change
+  re-prompts, including a rollback. **Fails closed:** a missing or unparseable manifest
+  shows the gate rather than skipping it.
+- `recordAcceptance(cfg, manifest)` — writes the acceptance record into the existing
+  config.
+
+Config shape, extending `PersistedConfig` in `app/src/main/main.ts:38`:
+
+```ts
+terms?: { version: string; acceptedAt: string; appVersion: string }
+```
+
+Per-machine and per-OS-user. There is no login to attach acceptance to, and inventing one
+for this would be disproportionate.
+
+### B3. Bundled text as source of truth
+
+- `app/legal/terms.md`, `app/legal/privacy.md`, `app/legal/manifest.json`
+  (`{ version, effective, summary }`).
+- `app/scripts/copy-assets.js` gains a copy of `legal/` into `dist/legal/` (it currently
+  copies only `index.html` and `styles.css` from `src/renderer`; it exists because
+  `mkdir -p && cp` broke the Windows build, so the addition follows the same `fs` style).
+- Rendered through the `marked` pipeline already present in `app/src/main/markdown.ts`.
+- Bumping the terms = edit markdown, bump `version`, set `summary`, ship a release.
+
+### B4. The overlay: `app/src/renderer/legal-gate.ts`
+
+A new file rather than more `renderer.ts`, which is already 1336 lines. Loaded as its own
+`<script>` exactly like `area-batch.js` and `vault-ui-state.js` are today
+(`app/src/renderer/index.html:184-185`). Styled as a sibling of `.onboard` and layered
+above it.
+
+- Wordmark → "Before you start" → effective date.
+- On a re-consent run, the manifest's `summary` renders as a "What changed" line so
+  returning users aren't stonewalled by an undifferentiated wall of text.
+- Segmented control **[Terms of Use] [Privacy Notice]** over one scroll pane — two
+  documents, one decision.
+- Checkbox "I have read and agree to the Memex Terms of Use and Privacy Notice" enables
+  **Agree and continue**. **Decline and quit** calls `app.quit()`. Standard clickwrap; no
+  scroll-lock, since forcing a scroll-to-bottom is friction that buys nothing.
+- "View online" links hand off to the system browser through the existing `shell:open`
+  path.
+- Reuses the established `inert` pattern (`app/src/renderer/renderer.ts:122`) to trap focus
+  while the gate is up.
+
+### B5. IPC and preload
+
+Two additions, following the existing `MemexApi` pattern (`app/src/shared/types.d.ts` is
+the single source of truth, `app/src/preload/preload.ts` annotates against it so drift is a
+compile error):
+
+- `legal:state` → `{ needsAcceptance: boolean, version, effective, summary, terms: string, privacy: string }`,
+  where `terms` and `privacy` are **rendered HTML**, not raw markdown. Rendering happens in
+  main via `markdown.ts`, matching how the app already treats main-rendered markdown as
+  authoritative (`app/src/renderer/renderer.ts:290`).
+- `legal:accept` → records acceptance, returns success
+
+Read-only review (B6) needs no additional IPC: it reuses `legal:state` and ignores
+`needsAcceptance`.
+
+### B6. Persistent access after acceptance
+
+The vault-switcher footer already holds `#appVersion` and "Reset tool approvals for this
+vault" (`app/src/renderer/index.html:179-180`) — the de facto settings surface. A "Terms of
+Use · Privacy" row joins it and reopens the same overlay read-only (no checkbox, just
+Close). No new settings panel.
+
+### B7. Package metadata
+
+`app/package.json` author email changes to `araj@cytopixel.com`. `license: "MIT"` and the
+author name stay as they are — MIT accurately describes CytoPixel's own code, and the
+bundled proprietary Anthropic components are addressed by the third-party components clause
+(A1 §5) rather than by changing this field. Deciding whether the shipped artifact needs a
+composite license notice is folded into the counsel review (open item 3).
+
+## Testing
+
+- **Unit** (`app/test/legal.test.cjs`, existing `node --test` suite): `needsAcceptance`
+  across first run, version match, version bump, malformed config, and missing manifest
+  (must fail closed); `recordAcceptance` round-trips through config without disturbing
+  `recent`/`last`/tool grants.
+- **Main-process enforcement:** `vault:open` and `vault:create` refuse while unaccepted.
+- **Driven run:** first launch gates → accept → relaunch is clean → bump the manifest
+  version → gate returns → decline quits.
+- **Packaged build:** required. `app/README.md` and `docs/RELEASING.md` are emphatic that
+  `npm start` does not exercise packaged asset paths, and this change adds new bundled
+  files that must land correctly in the built app.
+
+## Rollout
+
+Two repositories, two pull requests:
+
+1. `Memex` — bundled documents, `legal.ts`, gate UI, IPC, tests, `package.json` email.
+2. `cytopixel_website` — the two new per-product sections, transcribed from
+   `app/legal/*.md`.
+
+Canonical text lives in `app/legal/*.md`; the website sections are transcribed from it.
+Keeping those in sync manually is proportionate for two rarely-edited documents — add a
+line to `docs/RELEASING.md` rather than building a generator, with `version` and
+`effective` as the tell if they ever drift.

--- a/docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md
+++ b/docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md
@@ -250,6 +250,48 @@ bundled proprietary Anthropic components are addressed by the third-party compon
 (A1 §5) rather than by changing this field. Deciding whether the shipped artifact needs a
 composite license notice is folded into the counsel review (open item 3).
 
+## Part C — first-run folder-creation clarity (addendum)
+
+Bundled in because it lands on the same first-run surface, but independent of the gate.
+
+**Reported friction:** a user was advised to run `mkdir ~/code/my-vault` in Terminal before
+they could get started, and doing so unblocked them.
+
+**That step is not required, and must not be documented.** `tools/memex_init.py:318` calls
+`target.mkdir(parents=True, exist_ok=True)`, and `expandHome` (`app/src/main/main.ts:42`)
+expands a leading `~`, so typing `~/code/my-vault` into **Location** already works when
+`~/code` does not exist. Adding the instruction would bake an unnecessary step into
+onboarding. This is a discoverability failure, not a functional one.
+
+**Why the user concluded otherwise** — three UI signals all point at a pre-existing folder:
+
+1. `~/code/my-vault` is a `placeholder` attribute, not a value
+   (`app/src/renderer/index.html:162`), so it reads as a format example rather than a
+   promise to create anything. Nothing in the UI states the folder will be created.
+2. Both routes into that field are existing-folder pickers: the Location `…` button
+   (`app/src/renderer/renderer.ts:87`) and `Browse…` (line 80) both call
+   `dialog.showOpenDialog`. `createDirectory` is set (`app/src/main/main.ts:698`) so macOS
+   does offer "New Folder", but it is a small control in the dialog's bottom-left corner.
+3. `app/src/renderer/renderer.ts:84` — handed a non-vault folder, `Browse…` drops the path
+   into `f_path` and flashes *"That folder isn't a vault yet — create one here, or pick a
+   vault folder."* That is exactly the flow the reporter reached *after* their Terminal
+   step, so the app confirmed their theory that the folder had to exist first.
+
+**Fix — copy only, no behavior change:**
+
+1. A hint line under Location in the create form: "Doesn't exist yet? Memex creates it for
+   you, including parent folders."
+2. Reword the `renderer.ts:84` flash so it stops implying the folder had to pre-exist —
+   e.g. "That folder isn't a Memex vault yet. The form below can set one up there, or pick
+   another folder."
+
+**Related gap, out of scope, recorded so it isn't lost:** the reporter had Cowork rather
+than the Claude Code CLI. Vault creation still succeeds in that state (it needs only
+Python 3), but `startSession` fails and surfaces the "Agent session failed to start"
+warning — data panels work, chat does not. The CLI prerequisite currently appears only in
+small print in `.onboard-note` (`app/src/renderer/index.html:178`). Worth its own
+onboarding pass.
+
 ## Testing
 
 - **Unit** (`app/test/legal.test.cjs`, existing `node --test` suite): `needsAcceptance`
@@ -259,6 +301,10 @@ composite license notice is folded into the counsel review (open item 3).
 - **Main-process enforcement:** `vault:open` and `vault:create` refuse while unaccepted.
 - **Driven run:** first launch gates → accept → relaunch is clean → bump the manifest
   version → gate returns → decline quits.
+- **Part C regression:** in the same driven run, create a vault at a path whose parent does
+  not exist (e.g. `~/tmp-memex-parent/v1`) and confirm it succeeds without any prior
+  `mkdir`. Part C is copy-only, so this guards the behavior the copy now promises rather
+  than the copy itself.
 - **Packaged build:** required. `app/README.md` and `docs/RELEASING.md` are emphatic that
   `npm start` does not exercise packaged asset paths, and this change adds new bundled
   files that must land correctly in the built app.
@@ -267,7 +313,8 @@ composite license notice is folded into the counsel review (open item 3).
 
 Two repositories, two pull requests:
 
-1. `Memex` — bundled documents, `legal.ts`, gate UI, IPC, tests, `package.json` email.
+1. `Memex` — bundled documents, `legal.ts`, gate UI, IPC, tests, `package.json` email, and
+   the Part C copy fix.
 2. `cytopixel_website` — the two new per-product sections, transcribed from
    `app/legal/*.md`.
 

--- a/docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md
+++ b/docs/superpowers/specs/2026-07-26-memex-eula-consent-design.md
@@ -57,16 +57,17 @@ Established by reading the code, not assumed:
 - **Anthropic covers PHI only under a BAA with Zero Data Retention enabled**
   (Anthropic legal-and-compliance page), which gives the PHI prohibition a precise reason.
 
-## Open items — launch-gating, not resolved by this design
+## Anthropic-relationship risks — accepted, not launch-gating
 
-These are business/legal questions this document cannot settle. They are recorded here so
-they don't get lost, and they do not block implementation of the gate.
+Two questions surfaced while verifying the facts above. Neither is resolved by this design,
+and both are **accepted risks** by explicit decision rather than open action items. They are
+recorded because the reasoning matters if the situation changes.
 
 1. **Redistribution of the bundled Claude CLI.** Anthropic's legal-and-compliance page is
    silent on redistribution, embedding, or bundling; `LICENSE.md` says "All rights
    reserved", so no redistribution right is granted by default. Shipping the `claude`
-   binary inside a third-party DMG/installer needs express permission or a different
-   packaging approach.
+   binary inside a third-party DMG/installer would need express permission to be clearly
+   in bounds.
 2. **The OAuth credential model.** Anthropic's page states that OAuth auth "is intended
    exclusively for purchasers of Claude Free, Pro, Max, Team, and Enterprise subscription
    plans and is designed to support ordinary use of Claude Code and other native Anthropic
@@ -78,13 +79,46 @@ they don't get lost, and they do not block implementation of the gate.
    territory. Arguments that Memex is on the right side: it routes nothing through
    CytoPixel servers, does not implement Claude.ai login itself, and each user's
    credentials are used on their own machine for their own benefit — close to "ordinary,
-   individual usage". **Action: raise with Anthropic (sales/support) in parallel with
-   launch.** An EULA cannot resolve this; CytoPixel's own terms grant CytoPixel no rights
-   against Anthropic.
-3. **Counsel review** of both drafted documents before publication.
+   individual usage".
 
-Decision on record: proceed with the gate as designed, disclose the auth relationship in
-the terms, and pursue (1) and (2) with Anthropic in parallel.
+**Decision (2026-07-26):** proceed to launch without resolving either. Expected audience is
+small, enforcement against a local single-user app is unlikely, and if Anthropic does object
+there are direct contacts available to navigate it. If enforcement happens, the fallback is
+API-key auth as a documented path (see the option evaluated during design) and/or requiring
+the user's own installed CLI instead of bundling one. An EULA cannot resolve either question
+in any case — CytoPixel's own terms grant CytoPixel no rights against Anthropic — so the
+terms simply disclose the relationship accurately (A1 §4, §5).
+
+## Remaining open item
+
+**Counsel review** of both drafted documents before publication. Two specific questions
+worth their attention: whether MIT-licensed source undercuts the prohibited-use clauses
+(§7), and whether the shipped artifact needs a composite license notice given the bundled
+proprietary components.
+
+### License choice: MIT retained
+
+Considered and rejected switching the source to a more restrictive license to give the
+prohibited-use clauses copyright teeth:
+
+- **It cannot cover what is already published.** Existing releases stay MIT permanently and
+  anyone holding a copy retains those rights to it; relicensing binds only future code, so
+  it would not close the gap it was meant to close.
+- **It requires the outside contributor's consent.** Commit `4399161` (PR #15) touched
+  `tools/derive.py` and `tools/memex_bake.py`, and `memex_bake.py` ships inside the packaged
+  app via `extraResources` — so that contribution is in the distributed artifact, not merely
+  in the repo.
+- **The goal does not need it.** The prohibited-data clause exists to establish that the
+  user was told and agreed, which is contractual and evidentiary work that clickwrap
+  performs. Copyright-condition status would matter only for injunctive enforcement, which
+  is not the concern.
+- **It conflicts with CytoPixel's positioning** ("Open source, cloud-accessible, no forced
+  vendor lock-in"; NimbusImage is Apache 2.0).
+
+MIT also *strengthens* the part that matters most: it disclaims warranty and liability
+itself, so the terms restate rather than create that shield. The restriction that does hold
+cleanly without relicensing is the trademark reservation (A1 §3), which covers the realistic
+abuse case — someone shipping a modified build under the "Memex" name.
 
 ## Part A — the documents
 
@@ -248,7 +282,7 @@ Close). No new settings panel.
 author name stay as they are — MIT accurately describes CytoPixel's own code, and the
 bundled proprietary Anthropic components are addressed by the third-party components clause
 (A1 §5) rather than by changing this field. Deciding whether the shipped artifact needs a
-composite license notice is folded into the counsel review (open item 3).
+composite license notice is folded into the counsel review (see "Remaining open item").
 
 ## Part C — first-run folder-creation clarity (addendum)
 


### PR DESCRIPTION
Adds a blocking Terms of Use / Privacy Notice acceptance gate on first launch and whenever the terms version changes.

## Why

Memex is an assistant app that sends the contents of a user's vault to Anthropic under the user's own account. Nothing in the app said so. This adds the disclosure and records consent.

## Approach

**Enforcement lives in the main process, not the overlay.** `vault:open` and `vault:create` refuse until terms are accepted, so `MEMEX_OPEN=/path` and any UI bug cannot sail past a purely visual gate. The overlay is only how the user *satisfies* that check.

**The decision module is electron-free and fails closed.** `src/main/legal.ts` takes paths and values as parameters, like `grants.ts` and `security.ts`, so the whole decision surface is unit-testable. A missing, unreadable, or unparseable manifest, or an acceptance record of the wrong shape, all mean "show the gate" — re-reading terms is a nuisance, shipping an ungated build is not.

**Terms version is independent of app version.** `app/legal/manifest.json` carries it; bump only for substantive changes, since every bump re-prompts every user.

## What's here

- `app/legal/{terms.md,privacy.md,manifest.json}` — the documents, bundled into `dist/legal/` by `copy-assets.js` and rendered to HTML in the main process
- `src/main/legal.ts` — `loadLegal` / `needsAcceptance` / `acceptanceRecord` (11 unit tests)
- `src/renderer/legal-gate.ts` — the overlay, a self-contained IIFE that also owns the vault-switcher link that reopens it read-only
- Folder-creation copy fix: a user was told to `mkdir` a vault folder first. That was never required — `memex_init.py` mkdirs parents and `main.ts` expands `~`. Now the form says so.

## Verification

Driven against a running app via the `MEMEX_DEVCTL` harness with an isolated `--user-data-dir`:

- Pre-acceptance, `openVault` returned `Please accept the Terms of Use to continue` and `createVault` refused with no folder created
- Post-acceptance, `openVault('/tmp')` failed with `Not a Memex vault` — guard passed, real check ran
- Version bump 1.0 -> 1.1 re-prompts an already-accepted user with the "What changed" line; decline quits and leaves the old record intact
- **Packaged build**: all three documents inside `app.asar`, and the launched `.app` rendered real terms HTML rather than the "could not be loaded" fallback. The 5 Anthropic links survived the hardened markdown renderer
- Created a vault under two nonexistent parent directories, confirming the new hint's claim before shipping it

67/67 tests pass, typecheck clean.

## Note

The matching website sections are already live at [cytopixel.com/terms-of-service](https://cytopixel.com/terms-of-service/) and [cytopixel.com/privacy-policy](https://cytopixel.com/privacy-policy/), transcribed verbatim and verified word-for-word. Version and effective date must stay in sync with `app/legal/manifest.json` — see the new checklist item in `docs/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFQsK7bpAmCwrSMpxYM5BC