### PR TITLE
fix: root the quartz watcher's gitignore matcher at the vault, not cwd

### DIFF
--- a/hardened/quartz/quartz/build.ts
+++ b/hardened/quartz/quartz/build.ts
@@ -120,7 +120,25 @@ async function startWatching(
     })
   }
 
-  const gitIgnoredMatcher = await isGitIgnored()
+  // Root the gitignore matcher at the CONTENT directory, not process.cwd().
+  // `site:serve` runs from <vault>/quartz with `-d ..`, so an unrooted
+  // isGitIgnored() reads quartz/.gitignore and never sees the VAULT-root
+  // .gitignore. Every path the vault ignores there then looks un-ignored to the
+  // watcher, so the dev server watches files it should skip — and if anything
+  // writes to one during a build (a log, a generated artifact), each write
+  // retriggers a rebuild whose own output retriggers the next one: an infinite
+  // rebuild loop that live-reloads the browser forever.
+  //
+  // `ignorePatterns` currently masks the known instance of this (it lists
+  // `outputs/**`, where the serve log goes), so this is a latent defect here
+  // rather than a live one. It stops being latent the moment a vault gitignores
+  // a written-to path that ignorePatterns does not also list. That is not
+  // hypothetical: it is exactly what happened in the source vault, whose config
+  // lacks the `outputs/**` entry — ~80 rebuilds/sec for 1.5 days.
+  //
+  // Paths handed to `ignored` below are content-root-relative, so the matcher
+  // must be too.
+  const gitIgnoredMatcher = await isGitIgnored({ cwd: path.resolve(argv.directory) })
   const buildData: BuildData = {
     ctx,
     mut,


### PR DESCRIPTION
## What

`startWatching` in `hardened/quartz/quartz/build.ts` builds its ignore predicate with an unrooted `isGitIgnored()`, which resolves against `process.cwd()`. `site:serve` runs from `<vault>/quartz` with `-d ..`, so it reads `quartz/.gitignore` and **never sees the vault-root `.gitignore`**.

Result: every path a vault ignores at its root looks un-ignored to the watcher. One line:

```diff
-  const gitIgnoredMatcher = await isGitIgnored()
+  const gitIgnoredMatcher = await isGitIgnored({ cwd: path.resolve(argv.directory) })
```

The paths handed to `ignored` are all content-root-relative, so the matcher has to be too.

## Why it matters

The watcher watches files it should skip. If anything writes to one *during a build*, that write retriggers a rebuild, whose own output retriggers the next — an infinite rebuild loop that live-reloads the browser forever.

**This is currently latent in Memex, not live.** `ignorePatterns` happens to list `outputs/**`, which is where the serve log goes, so the second filter layer catches the known instance. It stops being latent the moment a vault gitignores a written-to path that `ignorePatterns` does not *also* list.

That is not hypothetical. It is exactly what happened in the source vault, whose `quartz.config.ts` lacks the `outputs/**` entry:

- `session-start-context.sh`, the launchd plist, and 11 skills all start the server with stdout redirected to `<vault>/outputs/quartz-serve.log` — inside the watched tree, and correctly so (moving it out of world-writable `/tmp` was deliberate hardening, per `docs/BACKPORT.md`).
- With the vault-root `.gitignore` invisible and no `outputs` entry in config, both filter layers missed it.
- The loop ran at **~80 rebuilds/sec for 1 day 15 hours** and produced a **58 MB** log before anyone noticed the browser reloading.

So the config entry is what saves Memex today, and this PR fixes the thing underneath it. Both layers should hold.

## Verification

| Check | Before | After |
|---|---|---|
| Isolated fixture: vault-root `.gitignore` ignores `scratch/`, `quartz/.gitignore` does not — `gitIgnored("scratch/run.log")` | `false` (watched) | `true` (ignored) |
| Live server, log inside the watched tree — rebuilds per 25s | 66 | **0** |
| Live reload on a real content edit — rebuilds from touching a published note | 1 | **1** (unchanged) |

That third row is the important counter-check: an over-broad ignore would have silently killed the watcher instead of fixing it.

Verified against globby 16.1.0, matching `hardened/quartz/package.json` (`^16.1.0`).

## Scope

- One file, one line of behavior change (plus explanatory comment).
- The copy under `app/release/mac-arm64/…/engine/` is an untracked build artifact and was left alone.
- `build.ts` contains no `{{template}}` tokens, so the bake/derive path copies it verbatim — nothing else to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9i4HfHCLAfLBr2yJ4k7VZ