### PR TITLE
run-trackers: make the tracker `# History` append an explicit step

### DIFF
--- a/packs/core/prompts/run-trackers.md
+++ b/packs/core/prompts/run-trackers.md
@@ -59,7 +59,14 @@ For each selected tracker, follow _workflows/run-tracker.md exactly:
    - miss_count: 0 if material, else miss_count + 1
    - If miss_count >= 5 after update, set status: needs_review.
 
-7. Append to log.md:
+7. Append ONE bullet to the tracker's # History (required by _schemas/tracker.md;
+   separate from the frontmatter above — last_digest is state, # History is provenance).
+   One line per run, INCLUDING material=false runs:
+   - <today> — <First run|Nth run|Run>. material=<bool>, <items_found> items
+     (<items_material> material). <headline, or "nothing material">.
+     <applied, or propose-only>. → [[Tracker Digest - <slug> - <today>]]
+
+8. Append to log.md:
    <datetime> — agent:tracker — <brief> — [[<subject>]] — material=<bool> items=<n>
 
 Honor forbidden_actions strictly throughout.

--- a/packs/core/skills/run-trackers/SKILL.md
+++ b/packs/core/skills/run-trackers/SKILL.md
@@ -120,7 +120,25 @@ Edit the tracker note:
 - If `miss_count >= 5` after the update, `status: needs_review` — let the auditor and the user decide whether to retune or retire.
 - `updated: <today>`
 
-### 2.7 Per-tracker log line
+### 2.7 Append to the tracker's `# History`
+
+**Do not skip this because 2.6 already set `last_digest`.** Those are different records: 2.6 stores *state* (the latest run), `# History` stores *provenance* (every run). `# History` is a required body section in `_schemas/tracker.md` — "bullet list of dated entries, each linking to a digest" — and it is the only place the tracker note itself shows its own arc.
+
+Append one bullet at the end of `# History`:
+
+```
+- <today> — <First run|Nth run|Run>. material=<true|false>, <items_found> items (<items_material> material). <one-sentence headline of what was material, or "nothing material">. <what was applied or proposed>. → [[Tracker Digest - <slug> - <today>]].
+```
+
+Rules:
+
+- **One line per run, always — including `material: false` runs.** A no-material run is a real observation, and it is what makes a climbing `miss_count` legible later. Silence in `# History` is indistinguishable from "never ran."
+- **Say what happened to `update_targets`:** "Applied a `# Changelog` line to [[X]]" when `auto_update_wiki: true`, or "Propose-only (`auto_update_wiki: false`) — nothing applied, no Tasks created" when false.
+- **One line.** The digest holds the detail; `# History` is the index.
+
+Why this step is called out explicitly: an omitted `# History` append is invisible — scheduling still works because `last_checked`/`next_check` are correct — so the tracker silently under-reports its run count for months. That destroys the evidence needed for the `miss_count >= 5` cadence-retune judgment, which is the one self-correcting mechanism trackers have.
+
+### 2.8 Per-tracker log line
 
 Append one line to `log.md`:
 

--- a/packs/core/workflows/run-tracker.md
+++ b/packs/core/workflows/run-tracker.md
@@ -21,7 +21,10 @@
    - `last_digest: [[<digest note>]]`
    - `miss_count: <0 if material else miss_count + 1>`
    - If `miss_count >= 5`, set `status: needs_review` (the auditor will propose lengthening cadence).
-9. Append to `log.md`:
+9. **Append one bullet to the tracker's `# History`** — required by `_schemas/tracker.md`, and separate from the frontmatter above (`last_digest` is state; `# History` is provenance). One line per run, **including `material: false` runs**:
+   `- <today> — <First run|Nth run|Run>. material=<bool>, <items_found> items (<items_material> material). <headline, or "nothing material">. <applied or propose-only>. → [[<digest note>]].`
+   Omitting this is invisible — scheduling keeps working because `last_checked`/`next_check` are right — so the tracker under-reports its run count indefinitely and the `miss_count >= 5` cadence-retune signal loses its evidence.
+10. Append to `log.md`:
    `<datetime> — agent:tracker — brief — [[<subject>]] — material=<bool> items=<n>`
 
 ## Cadence arithmetic


### PR DESCRIPTION
## The gap

`packs/core/schemas/tracker.md` lists `# History` as a required body section:

> - `# History` — bullet list of dated entries, each linking to a digest

But none of the three surfaces that specify a tracker run ever tell the agent to write it:

| Surface | Step that covers post-run bookkeeping | Mentions `# History`? |
|---|---|---|
| `packs/core/skills/run-trackers/SKILL.md` | 2.6 Update the tracker frontmatter | no |
| `packs/core/workflows/run-tracker.md` | 8. Update the tracker *(the canonical procedure)* | no |
| `packs/core/prompts/run-trackers.md` | 6. Update the tracker frontmatter | no |

All three list `last_checked` / `next_check` / `last_digest` / `miss_count` and stop there. So an agent that follows the procedure literally leaves `# History` empty forever, and an agent that writes it is going *beyond* the spec.

## Observed in a real vault

Both behaviours showed up in the same vault, a week apart:

- The **2026-07-16** run batch wrote `# History` entries on all three trackers it touched.
- The **2026-07-22** batch wrote digests, bumped frontmatter, and (where `auto_update_wiki: true`) edited the target project page — but wrote no `# History` line on any of the three.

The second batch wasn't sloppy; it was spec-compliant. One tracker's `# History` still ended at its creation date while `last_digest` pointed at a digest from two runs later.

## Why it stays hidden

Nothing surfaces as broken. `last_checked` and `next_check` are still correct, so scheduling works, due-ness is right, and the daily briefing reports normally. The tracker just quietly under-reports its own run count.

That matters because it erodes the evidence for the `miss_count >= 5` → `status: needs_review` path — the only self-correcting mechanism trackers have. Judging later whether a weekly tracker should have been monthly means reading its run log, and `# History` *is* that log. In the vault above, six of seven trackers were set to `weekly` while realistically moving fortnightly, and the History gaps made that harder to see rather than easier.

## The change

Adds the step to all three surfaces so they agree, and states the three things needed to keep it from being dropped again:

- **`last_digest` is state; `# History` is provenance** — having one doesn't excuse skipping the other. This is the specific reasoning error that makes 2.6 look complete.
- **A line is required even for `material: false` runs** — silence in `# History` is indistinguishable from "never ran," which is exactly what makes a climbing `miss_count` illegible.
- **One line per run** — the digest holds the detail; `# History` is the index.

Docs only, no behavioural code. Trailing step numbers renumbered in each file (skill `2.7 → 2.8`, workflow `9 → 10`, prompt `7 → 8`); no other cross-references point at them.

## Notes for review

- Wording deliberately references the **installed** paths (`_schemas/tracker.md`, `[[Tracker Digest - <slug> - <today>]]`) rather than `packs/core/…`, matching how the surrounding text in these files already reads at runtime in an installed vault.
- Not addressed here, but adjacent if you want it: `lint` has no check for "tracker has digests that aren't referenced in its `# History`." That's what would have caught this without a human noticing. Happy to add it in a follow-up.
