### PR TITLE
Fix truncated multi-day comms captures

### DIFF
--- a/packs/core/prompts/daily-briefing.md
+++ b/packs/core/prompts/daily-briefing.md
@@ -35,7 +35,12 @@ confirms regeneration.
 for enabled streams and `mailboxes.*`. Run `capture-comms` for {{date}}, then
 `reconcile-from-comms` in daily-briefing sub-mode, unless {{date}} is more than ~2 days
 old. Tier-A reversible bookkeeping auto-applies; Tier-B proposals become `## 0. State
-confirmation needed` and are confirmed in one batch after the briefing. The mail connector
+confirmation needed` and are confirmed in one batch after the briefing. The capture files also
+expose `## Coverage`: read it before reconciling. If any source says
+`status: partial`, retain its exact `coverage gap`, treat absence in its un-scanned range as
+inconclusive, set `comms_coverage: partial`, and put the warning at the top of §0 and the chat
+report-back even when there are no numbered state proposals. Never turn partial capture into
+"not sent," "no reply," or "quiet." The mail connector
 searches only `mailboxes.connected` (legacy vaults: `mailboxes.gmail_connected`): sent mail from `mailboxes.forwarding_in` or
 `mailboxes.other_sending_accounts` is invisible unless separately connected. Separately,
 `search_threads` can lag the connected mailbox itself (a stale cached view, days behind and
@@ -70,6 +75,7 @@ period_end: {{date}}
 includes_calendar: true
 includes_agent_queue: true
 includes_comms: <true if the default loop-closing pass ran; false if skipped>
+comms_coverage: <complete | partial | skipped>
 open_tasks_count: <count>
 projects_reviewed: <count>
 sensitivity: private

--- a/packs/core/prompts/daily-briefing.md
+++ b/packs/core/prompts/daily-briefing.md
@@ -32,9 +32,13 @@ immediately and tell the user. Do not overwrite it unless the user explicitly
 confirms regeneration.
 
 **Default loop-closing pass:** before gathering the inputs below, read `_config/sources.md`
-for enabled streams and `mailboxes.*`. Run `capture-comms` for {{date}}, then
-`reconcile-from-comms` in daily-briefing sub-mode, unless {{date}} is more than ~2 days
-old. Tier-A reversible bookkeeping auto-applies; Tier-B proposals become `## 0. State
+for enabled streams and `mailboxes.*`. Separate capture streams (email, Slack, and future capture
+providers) from calendar, which is reconciliation-only. If at least one capture stream is enabled,
+run `capture-comms` for {{date}} with only those streams; then run
+`reconcile-from-comms` in daily-briefing sub-mode for all enabled streams. If no capture streams
+are enabled, skip capture and stale digest parsing, but still reconcile an enabled calendar; set
+`includes_comms: false` and `comms_coverage: skipped`. Skip the whole pass when {{date}} is more
+than ~2 days old. Tier-A reversible bookkeeping auto-applies; Tier-B proposals become `## 0. State
 confirmation needed` and are confirmed in one batch after the briefing. The capture files also
 expose `## Coverage`: read it before reconciling. **Ignore stale digests from disabled sources:**
 exclude their whole files by `source:` frontmatter (filename stem for legacy files) before parsing
@@ -76,8 +80,8 @@ period_start: {{date}}
 period_end: {{date}}
 includes_calendar: true
 includes_agent_queue: true
-includes_comms: <true if the default loop-closing pass ran; false if skipped>
-comms_coverage: <complete | partial | skipped>
+includes_comms: <true if at least one capture stream ran; false otherwise>
+comms_coverage: <complete | partial when capture ran; skipped if no capture streams ran>
 open_tasks_count: <count>
 projects_reviewed: <count>
 sensitivity: private

--- a/packs/core/prompts/daily-briefing.md
+++ b/packs/core/prompts/daily-briefing.md
@@ -36,11 +36,13 @@ for enabled streams and `mailboxes.*`. Run `capture-comms` for {{date}}, then
 `reconcile-from-comms` in daily-briefing sub-mode, unless {{date}} is more than ~2 days
 old. Tier-A reversible bookkeeping auto-applies; Tier-B proposals become `## 0. State
 confirmation needed` and are confirmed in one batch after the briefing. The capture files also
-expose `## Coverage`: read it before reconciling. If any source says
-`status: partial`, retain its exact `coverage gap`, treat absence in its un-scanned range as
-inconclusive, set `comms_coverage: partial`, and put the warning at the top of §0 and the chat
-report-back even when there are no numbered state proposals. Never turn partial capture into
-"not sent," "no reply," or "quiet." The mail connector
+expose `## Coverage`: read it before reconciling. **Ignore stale digests from disabled sources:**
+exclude their whole files by `source:` frontmatter (filename stem for legacy files) before parsing
+either `## Coverage` or `## Action items`. If any enabled source says `status: partial`, retain its
+exact `coverage gap`, treat absence in its un-scanned range as inconclusive, set
+`comms_coverage: partial`, and put the warning at the top of §0 and the chat report-back even when
+there are no numbered state proposals. Never turn partial capture into "not sent," "no reply," or
+"quiet." The mail connector
 searches only `mailboxes.connected` (legacy vaults: `mailboxes.gmail_connected`): sent mail from `mailboxes.forwarding_in` or
 `mailboxes.other_sending_accounts` is invisible unless separately connected. Separately,
 `search_threads` can lag the connected mailbox itself (a stale cached view, days behind and

--- a/packs/core/schemas/briefing.md
+++ b/packs/core/schemas/briefing.md
@@ -22,6 +22,7 @@ period_end: YYYY-MM-DD
 includes_calendar: true
 includes_agent_queue: true
 includes_comms: true      # daily briefing ran the default capture-comms + reconcile loop (Step 1b)
+comms_coverage: complete  # complete | partial | skipped; never infer absence from partial coverage
 open_tasks_count: 0
 projects_reviewed: 0
 sensitivity: private      # briefings touch everything; default private
@@ -30,7 +31,7 @@ sensitivity: private      # briefings touch everything; default private
 
 ## Body sections (daily)
 
-- (optional) `## 0. State confirmation needed` — rendered above § 1 only when the default comms loop-closing pass ([[reconcile-from-comms]], via daily-briefing Step 1b) or the stale-state queries surface items whose vault status likely lags reality. Absent on a healthy day. Items are numbered for the batched "yes to 1,3" confirmation.
+- (optional) `## 0. State confirmation needed` — rendered above § 1 when the default comms loop-closing pass ([[reconcile-from-comms]], via daily-briefing Step 1b) or the stale-state queries surface items whose vault status likely lags reality, **or when `comms_coverage: partial`**. A partial capture starts the section with a warning naming each source/direction and un-scanned range; absence there is inconclusive. State proposals remain numbered for the batched "yes to 1,3" confirmation. Absent only when the pass has neither state items nor coverage gaps.
 1. `## 1. Top 3 outcomes for today`
 2. `## 2. Calendar / time map`
 3. `## 3. Tasks due or scheduled today`

--- a/packs/core/schemas/briefing.md
+++ b/packs/core/schemas/briefing.md
@@ -21,13 +21,18 @@ period_start: YYYY-MM-DD
 period_end: YYYY-MM-DD
 includes_calendar: true
 includes_agent_queue: true
-includes_comms: true      # daily briefing ran the default capture-comms + reconcile loop (Step 1b)
-comms_coverage: complete  # complete | partial | skipped; never infer absence from partial coverage
+includes_comms: true      # true iff at least one capture stream actually ran; calendar does not count
+comms_coverage: complete  # complete | partial if capture ran; skipped if no capture streams ran
 open_tasks_count: 0
 projects_reviewed: 0
 sensitivity: private      # briefings touch everything; default private
 ---
 ```
+
+`includes_comms` tracks capture execution, not the whole loop-closing pass: it is true only when
+at least one capture stream ran. If no capture streams ran — even when calendar reconciliation
+did — set `includes_comms: false` and `comms_coverage: skipped`. Never infer absence from partial
+coverage.
 
 ## Body sections (daily)
 

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -130,7 +130,11 @@ received. Received comms more often *open* loops (someone asks you for something
    default to **email + slack enabled** (calendar is not a capture stream — it has its
    own loop-closing path in the briefing; see [[reconcile-from-comms]]). If a stream is
    disabled, skip its scan entirely and don't write that source's file. This is the
-   per-stream gate the default daily-briefing flow relies on.
+   per-stream gate the default daily-briefing flow relies on. **Ignore stale digests from
+   disabled sources.** Do not delete an existing same-day file when its source is disabled — it
+   may carry hand annotations or a reconciliation ledger — but every downstream consumer must
+   exclude that file by its `source:` frontmatter (falling back to the filename stem for legacy
+   digests) before parsing it.
 
 1. **Resolve the date + scan window.** Date is today (or the date argument if given). Find the
    most recent prior `Inbox/comms/<date>/` folder to get the last run time; the window is
@@ -287,13 +291,18 @@ on the daily-briefing §0 "State confirmation needed" pre-flight) — is the hal
 vault state.
 
 **The handoff contract has two operational sections: `## Coverage` and `## Action items`.** Phase 2:
-1. Globs `Inbox/comms/<date>/*.md` and parses `## Coverage` first. It carries any partial source,
-   direction, and un-scanned range forward as inconclusive rather than negative evidence.
-2. Parses each `## Action items` block (the checkbox + `↳` format above is the item schema).
-3. For each item, resolves `likely target` to a real note and proposes the `suggested action`
+1. Reads the enabled capture streams from `_config/sources.md`, then globs
+   `Inbox/comms/<date>/*.md`. **Ignore stale digests from disabled sources:** exclude the whole
+   file before parsing either `## Coverage` or `## Action items`, using `source:` frontmatter and
+   the filename stem as the legacy fallback. This preserves the file on disk without letting its
+   old coverage or action items affect the current run.
+2. Parses `## Coverage` from the remaining enabled-source files first. It carries any partial
+   source, direction, and un-scanned range forward as inconclusive rather than negative evidence.
+3. Parses each `## Action items` block (the checkbox + `↳` format above is the item schema).
+4. For each item, resolves `likely target` to a real note and proposes the `suggested action`
    (close Task, flip Letter `drafting→submitted`, bump Person `last_contact`/`next_touch`, mark
    Followup `acted_on`).
-4. Auto-applies only the trivial/reversible ones (bump `last_contact`, mark a Followup); surfaces
+5. Auto-applies only the trivial/reversible ones (bump `last_contact`, mark a Followup); surfaces
    the consequential/irreversible ones (close a p1 Task, flip a Letter to submitted, anything
    needing a final Work-log narrative) for explicit user confirmation before applying.
 

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -43,6 +43,11 @@ You are running as **`agent:capture`** for this skill.
 - **Ruthless on noise.** Most email/Slack is not loop-relevant. Action items are *only* items
   that open or close a vault loop. Everything else is a one-line count in `## Filtered as noise`
   — never a silent cap.
+- **No silent caps or truncation.** For every enabled provider stream — including any
+  vault-specific Notion or Jira scan — enumerate the whole resolved window with bounded daily
+  slices and/or pagination to exhaustion. Never treat the first page as complete. If a scan is
+  interrupted, rate-limited, or otherwise stopped early, record the un-scanned range as an
+  explicit `coverage gap`; never turn partial coverage into a claim that the period was quiet.
 - **No fabrication.** Every action item traces to a real message. If you can't find a likely
   vault target, say `(no obvious target)` — don't invent a note name.
 - **Idempotent.** Re-running for the same date regenerates the day's files in place (same path)
@@ -50,21 +55,25 @@ You are running as **`agent:capture`** for this skill.
 
 ## Output shape (decided + documented)
 
-**Two files per day, not one combined file:**
+**One file per enabled capture stream, not one combined file.** The default install has two:
 
 ```
 Inbox/comms/<YYYY-MM-DD>/email.md
 Inbox/comms/<YYYY-MM-DD>/slack.md
+# A vault-specific provider scan follows the same shape at <source>.md.
 ```
 
 Rationale: (1) the mail and Slack connectors are independently authenticated MCP servers with independent
 failure modes — if Slack auth is absent in a given run, the email file still lands clean and the
 Slack file records the gap, rather than one combined file being half-empty with no signal why;
 (2) it mirrors the shape the source idea note specified; (3) each source gets source-appropriate
-provenance. Phase 2 globs `Inbox/comms/<date>/*.md` and reads the `## Action items` section from
-both — the seam is per-section, not per-file, so two files cost it nothing.
+provenance. Phase 2 globs `Inbox/comms/<date>/*.md` and reads the operational `## Coverage` and
+`## Action items` sections from each — the seam is per-section, not per-file, so separate source
+files cost it nothing.
 
-Each file carries this frontmatter and these four sections:
+Each file carries this frontmatter and these five sections. `## Coverage` is operational data,
+not optional commentary: phase 2 and the briefing use it to distinguish a complete capture from
+a plausible-looking partial one.
 
 ```markdown
 ---
@@ -77,6 +86,11 @@ sensitivity: private           # NEVER lower — these are private comms
 generated_by: capture-comms
 phase: 1-capture-only          # APPLIES NOTHING; phase 2 reconciles
 ---
+
+## Coverage
+- status: complete             # or: partial
+- scanned: <directions, bounded time slices, and page counts actually exhausted>
+- coverage gap: none           # or: <direction + un-scanned time range/slice + reason/next cursor>
 
 ## Summary
 3–6 bullets — the gist of the day's <email|Slack>. What moved, who needs what.
@@ -131,16 +145,30 @@ received. Received comms more often *open* loops (someone asks you for something
    ToolSearch: select:mcp__claude_ai_Slack__slack_search_public_and_private,mcp__claude_ai_Slack__slack_read_channel,mcp__claude_ai_Slack__slack_read_thread,mcp__claude_ai_Slack__slack_read_user_profile,mcp__claude_ai_Slack__slack_search_users
    ```
    If either server is unavailable (interactive auth absent — a documented caveat for
-   headless/cron runs), **do not fail the whole run**: write that source's file with an empty
-   body and a `> ⚠️ <source> unavailable this run (auth/connection)` note at the top, and
-   proceed with the other source. This is exactly the partial-failure case the two-file split
-   exists to handle.
+   headless/cron runs), **do not fail the whole run**: write that source's standard digest with
+   `status: partial`, a `coverage gap` naming the full un-scanned window, and a
+   `> ⚠️ <source> unavailable this run (auth/connection)` note at the top. Then proceed with the
+   other source. This is exactly the partial-failure case the two-file split exists to handle.
 
 3. **Scan mail — both directions** (only if `email` is enabled per Step 0). Use the [[email]] broad-search technique (don't start
    narrow; on Microsoft 365 use the connector's own search parameters, not Gmail operators). Cover sent AND received in the window:
-   - Received: the inbox for the window (Gmail: `in:inbox newer_than:<window>`, plus a wider
-     `in:anywhere newer_than:<window>` for threads that skip the inbox).
-   - **Sent mail in the window** (Gmail: `in:sent newer_than:<window>`) — the loop-closing gold. What did *I* send today?
+   - Received: the inbox in each bounded window/slice (Gmail: `in:inbox` plus the slice bounds),
+     plus a wider `in:anywhere` pass for threads that skip the inbox.
+   - **Sent mail in each bounded window/slice** (Gmail: `in:sent` plus the slice bounds) — the
+     loop-closing gold. What did *I* send?
+   - **Enumerate the full window, not just the newest page.** When the window exceeds 2 days,
+     split each received and sent search into bounded, non-overlapping **calendar-day slices** in
+     the vault timezone. Use the provider's explicit start/end parameters where available. For
+     Gmail date operators, widen the query boundaries enough to absorb their date semantics, then
+     discard messages outside the exact slice by timestamp. Within every slice — and for shorter
+     windows too — follow `nextPageToken`, `cursor`, or the provider's equivalent until it is
+     absent. Search results may be newest-first and capped: **never treat the first page as
+     complete coverage**. De-duplicate the overlapping inbox/anywhere searches by `threadId`.
+   - Track the direction, exact slice bounds, and pages exhausted for `## Coverage`. If any query
+     stops before pagination is exhausted, mark the file `status: partial` and name the remaining
+     un-scanned slice/range and next cursor in `coverage gap`. A completed pagination walk means
+     only that the connector's returned result set was enumerated; it does not prove a stale index
+     is fresh or that a different mailbox was visible.
    - For any thread that looks loop-relevant, `get_thread` with `messageFormat: FULL_CONTENT` to
      read the actual chain before classifying (snippets hide the substance). Record that thread's
      `threadId` in the action item's `↳ thread:` field so phase-2 reconcile can re-confirm via
@@ -165,6 +193,11 @@ received. Received comms more often *open* loops (someone asks you for something
 4. **Scan Slack — both directions, including what I sent** (only if `slack` is enabled per Step 0).
    - Resolve the user's own Slack identity first (`slack_read_user_profile` /
      `slack_search_users`) so you can recognize `from:<me>`.
+   - When the window exceeds 2 days, split both searches below into bounded calendar-day slices
+     using explicit epoch `after`/`before` parameters (with local timestamp filtering at the
+     boundaries). Paginate every slice to exhaustion. Record each slice and page count in
+     `## Coverage`; if a slice is cut short, mark the digest partial and record its un-scanned
+     remainder and next cursor as a `coverage gap`.
    - Search messages **I sent** in the window (`slack_search_public_and_private` filtered to the
      user as author) — "I sent the form to Riley", "shipped the deploy", "replied to the review"
      are the strongest close signals.
@@ -212,17 +245,27 @@ received. Received comms more often *open* loops (someone asks you for something
      correspondent, `create-task` for a concrete new action).
    - **Noise** — everything else. Count it; one line in `## Filtered as noise`.
 
-6. **Write the two files (idempotent).** First, run the **completeness self-check** — answer all
-   four honestly; any "no" means go back before writing:
-   1. Did my author-search use `after:<window_start date − 1 day>` rather than the window's own
-      date? (`after:` is exclusive — see the Step 4 warning.) If not, re-run it → Step 4.
-   2. Did I **paginate** to exhaustion, and did I `slack_read_channel` every distinct conversation
-      ID the search surfaced? A capped single page is not coverage → Step 4.
-   3. Does the digest contain any completeness claim — "quiet", "no DMs besides X", "nothing from
-      Y" — resting on a search result rather than a `slack_read_channel` read? Verify it or delete it.
-   4. Sanity-check the magnitude: is the message count plausible for the window length and this
-      user's activity? **Three messages for a workday is a bug, not a quiet day.** Nothing inside a
-      truncated digest looks wrong — only the count does.
+6. **Write the per-source files (idempotent).** First, run the **completeness self-check for every
+   enabled source or stream**. Retry a recoverable gap before writing; if auth, rate limits, tool
+   failure, or time prevents completion, still write the digest as partial rather than losing the
+   successfully captured material:
+   1. Is there a coverage plan for every direction/query, with bounded calendar-day slices for a
+      window over 2 days? Were all planned slices attempted?
+   2. Was every slice **paginated to exhaustion**? A capped first page is not coverage. If not,
+      does `## Coverage` say `status: partial` and identify the direction, un-scanned time
+      range/slice, reason, and next cursor/token (when one exists) as a `coverage gap`?
+   3. For Slack, did the author-search use `after:<window_start date − 1 day>` rather than the
+      window's own date, and did `slack_read_channel` cover every distinct conversation ID the
+      search surfaced? If not, retry Step 4 or record the exact unscanned remainder as a gap.
+   4. Does the digest contain any completeness claim — "quiet", "no DMs besides X", "nothing from
+      Y" — resting on a search result or a partial scan? Verify it with the source read or delete it.
+   5. Sanity-check the magnitude against the window length and this user's activity. **Three
+      messages for a workday is a bug, not a quiet day.** An implausible count requires another
+      pass or an explicit coverage gap; nothing inside a truncated digest looks wrong by itself.
+
+   Apply the same self-check to any additional enabled provider scan supplied by the vault (for
+   example Notion or Jira): bounded slices or cursor exhaustion, never a first-page assumption,
+   and an explicit un-scanned remainder whenever coverage is partial.
 
    Then: `mkdir -p Inbox/comms/<date>` once. For each source: if
    the file already exists, **Read it first**; if it looks hand-edited or annotated below the
@@ -243,13 +286,14 @@ idea. Phase 2 — a *separate* `reconcile-from-comms` skill (propose-only, manua
 on the daily-briefing §0 "State confirmation needed" pre-flight) — is the half that mutates
 vault state.
 
-**The handoff contract is the `## Action items` section.** Phase 2:
-1. Globs `Inbox/comms/<date>/*.md`, parses each `## Action items` block (the checkbox + `↳`
-   format above is the schema).
-2. For each item, resolves `likely target` to a real note and proposes the `suggested action`
+**The handoff contract has two operational sections: `## Coverage` and `## Action items`.** Phase 2:
+1. Globs `Inbox/comms/<date>/*.md` and parses `## Coverage` first. It carries any partial source,
+   direction, and un-scanned range forward as inconclusive rather than negative evidence.
+2. Parses each `## Action items` block (the checkbox + `↳` format above is the item schema).
+3. For each item, resolves `likely target` to a real note and proposes the `suggested action`
    (close Task, flip Letter `drafting→submitted`, bump Person `last_contact`/`next_touch`, mark
    Followup `acted_on`).
-3. Auto-applies only the trivial/reversible ones (bump `last_contact`, mark a Followup); surfaces
+4. Auto-applies only the trivial/reversible ones (bump `last_contact`, mark a Followup); surfaces
    the consequential/irreversible ones (close a p1 Task, flip a Letter to submitted, anything
    needing a final Work-log narrative) for explicit user confirmation before applying.
 

--- a/packs/core/skills/capture-comms/SKILL.md
+++ b/packs/core/skills/capture-comms/SKILL.md
@@ -167,14 +167,20 @@ received. Received comms more often *open* loops (someone asks you for something
      discard messages outside the exact slice by timestamp. Within every slice — and for shorter
      windows too — follow `nextPageToken`, `cursor`, or the provider's equivalent until it is
      absent. Search results may be newest-first and capped: **never treat the first page as
-     complete coverage**. De-duplicate the overlapping inbox/anywhere searches by `threadId`.
+     complete coverage**. After pagination, build one global `threadId` map across all calendar-day slices and query variants
+     (`in:inbox`, `in:anywhere`, and `in:sent`), including every page and sent/received
+     direction.
+     Merge repeated hits into the existing entry, preserving
+     direction, exact slice bounds, timestamps, and query provenance. Only after every planned
+     search is enumerated, read each unique thread with `get_thread` and classify it once.
    - Track the direction, exact slice bounds, and pages exhausted for `## Coverage`. If any query
      stops before pagination is exhausted, mark the file `status: partial` and name the remaining
      un-scanned slice/range and next cursor in `coverage gap`. A completed pagination walk means
      only that the connector's returned result set was enumerated; it does not prove a stale index
      is fresh or that a different mailbox was visible.
-   - For any thread that looks loop-relevant, `get_thread` with `messageFormat: FULL_CONTENT` to
-     read the actual chain before classifying (snippets hide the substance). Record that thread's
+   - For any unique thread that looks loop-relevant, use the global entry's one `get_thread` read
+     with `messageFormat: FULL_CONTENT` to inspect the actual chain before classifying (snippets
+     hide the substance). Record that thread's
      `threadId` in the action item's `↳ thread:` field so phase-2 reconcile can re-confirm via
      `get_thread` without re-searching a possibly-stale index.
    - Mailbox visibility: the mail connector searches only the connected mailbox, `{{OWNER_PRIMARY_EMAIL}}`{{?OWNER_FORWARDING_EMAIL}}.

--- a/packs/core/skills/daily-briefing/SKILL.md
+++ b/packs/core/skills/daily-briefing/SKILL.md
@@ -48,9 +48,9 @@ This is the default multi-source pass that keeps vault state from lagging realit
 
 2. **Backfill guard.** If `<date>` is more than ~2 days in the past (a backfilled briefing), **skip the comms refresh** — a comms scan only makes sense near today — and note `(comms refresh skipped — backfilled briefing for a past date)` in §0. Generate from vault state alone.
 
-3. **Run [[capture-comms]]** for `<date>`, enabled streams only. It is read-only against mail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`.
+3. **Run [[capture-comms]]** for `<date>`, enabled streams only. It is read-only against mail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`. Read every generated `## Coverage` block immediately: retain each `status: partial` / `coverage gap` with its source, direction, un-scanned time range, and reason. A partial scan's positive hits are usable, but absence inside its gap is inconclusive.
 
-4. **Run [[reconcile-from-comms]]** for `<date>` in its **briefing sub-mode** (see that skill's "When invoked by daily-briefing"): it auto-applies Tier-A reversible bookkeeping (bump `last_contact`, mark Followups `acted_on`) and **returns the Tier-B proposals** — task closes, Letter→submitted, and (if the `calendar` stream is enabled) passed-event closes — **without prompting**. Hold those proposals for §0 and the batched report-back (Step 6).
+4. **Run [[reconcile-from-comms]]** for `<date>` in its **briefing sub-mode** (see that skill's "When invoked by daily-briefing"): it auto-applies Tier-A reversible bookkeeping (bump `last_contact`, mark Followups `acted_on`) and **returns the Tier-B proposals plus any coverage gaps** — task closes, Letter→submitted, and (if the `calendar` stream is enabled) passed-event closes — **without prompting**. Hold those proposals and gaps for §0 and the batched report-back (Step 6).
 
 Tasks that Tier-A already advanced will read correctly through the rest of the briefing. Tier-B proposals are **not** applied here — the user confirms them in one batch in Step 6, preserving the "agents never self-close" guardrail.
 
@@ -84,6 +84,13 @@ Also pull yesterday's briefing's "## Shutdown notes" section if present — it c
 
 When (a) and (b) point at the same note, keep the reconcile proposal (it carries the signal) and drop the duplicate. If Step 1b was skipped (no streams enabled, or the backfill guard fired), § 0 is just (b).
 
+**Coverage gaps are warnings, not state proposals.** If any capture file says `status: partial`,
+render `## 0. State confirmation needed` even when there are no numbered closes. Put this warning
+first: `> ⚠️ Comms coverage is partial — <source/direction>: <un-scanned range> (<reason>). Absence
+in that range is inconclusive.` Do not create an "awaiting send," "no reply," or "quiet" item from
+the uncovered range. Set frontmatter `comms_coverage: partial`; otherwise use `complete` when every
+enabled comms source completed and `skipped` when Step 1b did not run.
+
 For outbound-contact tasks (reply/send/email/follow-up tasks), do **not** infer "awaiting send" from stale note state alone when email is enabled. Step 1b's live comms capture (or a same-day `Inbox/comms/<date>/` digest) is the prerequisite. If the connected-mailbox search missed the send but the task/person uses a non-connected sending account, render the item as "couldn't confirm from the connected mailbox — may have gone from <account>" and ask the user, rather than asserting it remains open. The connected-mailbox search can also be **stale** (the search index lags reality and a repeat search won't refresh it), so a send that search can't see is "couldn't confirm" even without a second account — verify the specific thread with a full-thread read (Gmail: `get_thread(threadId)`) before asserting anything, and never emit "awaiting send" / "unsent" off an empty search.
 
 Four pre-flight queries (run in parallel):
@@ -98,6 +105,10 @@ For each item (from either source), render a line in a new **`## 0. State confir
 ```markdown
 ## 0. State confirmation needed
 
+<IF CAPTURE PARTIAL:>
+> ⚠️ Comms coverage is partial — <source/direction>: <un-scanned range> (<reason>). Absence in that range is inconclusive.
+
+<IF THERE ARE STATE PROPOSALS:>
 The vault thinks the following are still in progress. Were any of them already done?
 
 1. [[<Task or Letter wikilink>]] — `status: <current>` (due <date>).
@@ -107,7 +118,9 @@ The vault thinks the following are still in progress. Were any of them already d
 Reply with the numbers that are done (e.g. "yes to 1,3") and the planner will close them via [[close-task]].
 ```
 
-Number the items so the Step 6 batched confirm ("yes to 1,3,4") maps cleanly. If § 0 is empty (no reconcile proposals and no query hits), omit the section entirely — its absence is the signal of a healthy vault.
+Number the items so the Step 6 batched confirm ("yes to 1,3,4") maps cleanly. Omit §0 only when
+there are no reconcile proposals, no query hits, **and no coverage gaps** — its absence then means
+the pass completed without surfacing stale state or partial capture.
 
 **In the chat report-back (Step 6),** also surface this list above the Top 3 — see Step 6.
 
@@ -130,6 +143,7 @@ period_end: <date>
 includes_calendar: true
 includes_agent_queue: true
 includes_comms: <true if Step 1b ran; false if skipped>
+comms_coverage: <complete | partial | skipped>
 open_tasks_count: <count>
 projects_reviewed: <count>
 sensitivity: private
@@ -217,6 +231,9 @@ Skip this step only if the user explicitly says "don't open it" or "just write t
 ```
 Briefing generated: Ops/Briefings/<date>.md (opened in browser at http://localhost:{{QUARTZ_PORT}}/Ops/Briefings/<date>).
 
+<IF COMMS COVERAGE IS PARTIAL:>
+**Comms coverage is partial:** <source/direction> did not scan <range> (<reason>). Absence in that range is inconclusive.
+
 <IF § 0 has items:>
 **Confirm these closes** (vault may be lagging reality — from your comms/calendar + a vault scan):
 1. [[<item 1>]] — still <status>. <signal, if reconcile-sourced>
@@ -231,7 +248,12 @@ Top 3 outcomes:
 Notable: <one bullet for the most consequential at-risk project or surfaced followup, or "nothing surprising">.
 ```
 
-Surface the § 0 items at the top of the chat report-back if present — the user reads the chat before opening the briefing file, and closing stale state in the same session is the whole point. This is the **single batched confirmation** for everything Step 1b proposed. When the user confirms ("yes to 1,3"):
+Surface any coverage gap at the top of the chat report-back, before §0 confirmations and the Top
+3. The user must see when the comms capture is partial; never let a successfully written briefing
+make an un-scanned range look complete. Then surface the § 0 items if present — the user reads the
+chat before opening the briefing file, and closing stale state in the same session is the whole
+point. This is the **single batched confirmation** for everything Step 1b proposed. When the user
+confirms ("yes to 1,3"):
 
 - **Task closes → route through [[close-task]]** (never hand-edit `status: done` — close-task enforces the final `# Work log` entry and the `unblocks:` cascade, and the "agents never self-close" guardrail means this confirmation is what authorizes it).
 - **Letter `drafting → submitted`** → the clean two-field edit (`status:` + `submitted:`), per [[reconcile-from-comms]].

--- a/packs/core/skills/daily-briefing/SKILL.md
+++ b/packs/core/skills/daily-briefing/SKILL.md
@@ -44,15 +44,21 @@ If today's briefing already has a `## Shutdown notes` section appended (from `sh
 
 This is the default multi-source pass that keeps vault state from lagging reality. It runs **before** synthesis so §0 and the task list reflect what actually happened off-vault (you answered an email, posted in Slack, a meeting ended).
 
-1. **Read `_config/sources.md`.** Determine which streams are `enabled: true`. Also read `mailboxes.*` if present: `mailboxes.connected` (legacy vaults: `mailboxes.gmail_connected`) is the only mailbox the mail connector searches; `mailboxes.forwarding_in` may cover received mail only; `mailboxes.other_sending_accounts` are outbound identities whose sent mail is invisible unless separately connected. If the file is absent (older vault), default to **email + slack enabled, calendar planning-only**. If no streams are enabled, skip to Step 2 — the §0 stale-state queries remain as the fallback safety net.
+1. **Read `_config/sources.md`.** Determine which streams are `enabled: true`, and separately track the enabled **capture streams** handled by [[capture-comms]] (email, Slack, and any future capture providers). Calendar is reconciliation-only and is not a capture stream. Also read `mailboxes.*` if present: `mailboxes.connected` (legacy vaults: `mailboxes.gmail_connected`) is the only mailbox the mail connector searches; `mailboxes.forwarding_in` may cover received mail only; `mailboxes.other_sending_accounts` are outbound identities whose sent mail is invisible unless separately connected. If the file is absent (older vault), default to **email + slack enabled, calendar planning-only**. If no streams of any kind are enabled, skip to Step 2 — the §0 stale-state queries remain as the fallback safety net.
 
 2. **Backfill guard.** If `<date>` is more than ~2 days in the past (a backfilled briefing), **skip the comms refresh** — a comms scan only makes sense near today — and note `(comms refresh skipped — backfilled briefing for a past date)` in §0. Generate from vault state alone.
 
-3. **Run [[capture-comms]]** for `<date>`, enabled streams only. It is read-only against mail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`. **Ignore stale digests from disabled sources:** using `source:` frontmatter (or the filename stem for legacy files), read `## Coverage` only from files whose source is in the enabled set resolved in item 1. Retain each selected `status: partial` / `coverage gap` with its source, direction, un-scanned time range, and reason. A partial scan's positive hits are usable, but absence inside its gap is inconclusive.
+3. **Run [[capture-comms]]** for `<date>` only when at least one capture stream is enabled, passing only those enabled capture streams. It is read-only against mail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`. **Ignore stale digests from disabled sources:** using `source:` frontmatter (or the filename stem for legacy files), read `## Coverage` only from files whose source is in the enabled capture-stream set resolved in item 1. Retain each selected `status: partial` / `coverage gap` with its source, direction, un-scanned time range, and reason. A partial scan's positive hits are usable, but absence inside its gap is inconclusive. If no capture streams are enabled, skip capture and digest parsing, but continue to item 4 so an enabled calendar can still reconcile passed events.
 
 4. **Run [[reconcile-from-comms]]** for `<date>` in its **briefing sub-mode** (see that skill's "When invoked by daily-briefing"): it auto-applies Tier-A reversible bookkeeping (bump `last_contact`, mark Followups `acted_on`) and **returns the Tier-B proposals plus any coverage gaps** — task closes, Letter→submitted, and (if the `calendar` stream is enabled) passed-event closes — **without prompting**. Hold those proposals and gaps for §0 and the batched report-back (Step 6).
 
 Tasks that Tier-A already advanced will read correctly through the rest of the briefing. Tier-B proposals are **not** applied here — the user confirms them in one batch in Step 6, preserving the "agents never self-close" guardrail.
+
+Coverage frontmatter records capture execution independently of calendar reconciliation.
+`includes_comms` is true only if at least one capture stream actually ran. If no capture streams
+ran — including a calendar-only Step 1b — set `includes_comms: false` and
+`comms_coverage: skipped`. When one or more capture streams ran, use `partial` if any enabled
+capture source was incomplete and `complete` only if every enabled capture source completed.
 
 If the contact/send status depends on mail that may have been sent from a non-connected account, the comms pass can only return an **inconclusive** prompt ("couldn't confirm from the connected mailbox; did this go from <account>?"). Never convert an empty connected-mailbox sent-mail search into "not sent" / "awaiting send" when the relevant thread may live in `mailboxes.other_sending_accounts` or the forwarding-in account's own sent folder.
 
@@ -89,8 +95,9 @@ When (a) and (b) point at the same note, keep the reconcile proposal (it carries
 Put this warning first: `> ⚠️ Comms coverage is partial — <source/direction>: <un-scanned range>
 (<reason>). Absence in that range is inconclusive.` Do not create an "awaiting send," "no reply,"
 or "quiet" item from the uncovered range. Set frontmatter `comms_coverage: partial`; otherwise use
-`complete` when every enabled comms source completed and `skipped` when Step 1b did not run. A
-disabled source's leftover digest never participates in this status.
+`complete` when every enabled capture source completed and `skipped` when no capture stream ran.
+A disabled source's leftover digest never participates in this status, and calendar
+reconciliation alone never upgrades capture coverage.
 
 For outbound-contact tasks (reply/send/email/follow-up tasks), do **not** infer "awaiting send" from stale note state alone when email is enabled. Step 1b's live comms capture (or a same-day `Inbox/comms/<date>/` digest) is the prerequisite. If the connected-mailbox search missed the send but the task/person uses a non-connected sending account, render the item as "couldn't confirm from the connected mailbox — may have gone from <account>" and ask the user, rather than asserting it remains open. The connected-mailbox search can also be **stale** (the search index lags reality and a repeat search won't refresh it), so a send that search can't see is "couldn't confirm" even without a second account — verify the specific thread with a full-thread read (Gmail: `get_thread(threadId)`) before asserting anything, and never emit "awaiting send" / "unsent" off an empty search.
 
@@ -143,8 +150,8 @@ period_start: <date>
 period_end: <date>
 includes_calendar: true
 includes_agent_queue: true
-includes_comms: <true if Step 1b ran; false if skipped>
-comms_coverage: <complete | partial | skipped>
+includes_comms: <true if at least one capture stream ran; false otherwise>
+comms_coverage: <complete | partial when capture ran; skipped if no capture streams ran>
 open_tasks_count: <count>
 projects_reviewed: <count>
 sensitivity: private

--- a/packs/core/skills/daily-briefing/SKILL.md
+++ b/packs/core/skills/daily-briefing/SKILL.md
@@ -48,7 +48,7 @@ This is the default multi-source pass that keeps vault state from lagging realit
 
 2. **Backfill guard.** If `<date>` is more than ~2 days in the past (a backfilled briefing), **skip the comms refresh** — a comms scan only makes sense near today — and note `(comms refresh skipped — backfilled briefing for a past date)` in §0. Generate from vault state alone.
 
-3. **Run [[capture-comms]]** for `<date>`, enabled streams only. It is read-only against mail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`. Read every generated `## Coverage` block immediately: retain each `status: partial` / `coverage gap` with its source, direction, un-scanned time range, and reason. A partial scan's positive hits are usable, but absence inside its gap is inconclusive.
+3. **Run [[capture-comms]]** for `<date>`, enabled streams only. It is read-only against mail/Slack and handles a per-source MCP outage gracefully (writes a gap note, continues), so a missing connector never fails the briefing. This refreshes `Inbox/comms/<date>/`. **Ignore stale digests from disabled sources:** using `source:` frontmatter (or the filename stem for legacy files), read `## Coverage` only from files whose source is in the enabled set resolved in item 1. Retain each selected `status: partial` / `coverage gap` with its source, direction, un-scanned time range, and reason. A partial scan's positive hits are usable, but absence inside its gap is inconclusive.
 
 4. **Run [[reconcile-from-comms]]** for `<date>` in its **briefing sub-mode** (see that skill's "When invoked by daily-briefing"): it auto-applies Tier-A reversible bookkeeping (bump `last_contact`, mark Followups `acted_on`) and **returns the Tier-B proposals plus any coverage gaps** — task closes, Letter→submitted, and (if the `calendar` stream is enabled) passed-event closes — **without prompting**. Hold those proposals and gaps for §0 and the batched report-back (Step 6).
 
@@ -84,12 +84,13 @@ Also pull yesterday's briefing's "## Shutdown notes" section if present — it c
 
 When (a) and (b) point at the same note, keep the reconcile proposal (it carries the signal) and drop the duplicate. If Step 1b was skipped (no streams enabled, or the backfill guard fired), § 0 is just (b).
 
-**Coverage gaps are warnings, not state proposals.** If any capture file says `status: partial`,
-render `## 0. State confirmation needed` even when there are no numbered closes. Put this warning
-first: `> ⚠️ Comms coverage is partial — <source/direction>: <un-scanned range> (<reason>). Absence
-in that range is inconclusive.` Do not create an "awaiting send," "no reply," or "quiet" item from
-the uncovered range. Set frontmatter `comms_coverage: partial`; otherwise use `complete` when every
-enabled comms source completed and `skipped` when Step 1b did not run.
+**Coverage gaps are warnings, not state proposals.** If any **enabled-source** capture file says
+`status: partial`, render `## 0. State confirmation needed` even when there are no numbered closes.
+Put this warning first: `> ⚠️ Comms coverage is partial — <source/direction>: <un-scanned range>
+(<reason>). Absence in that range is inconclusive.` Do not create an "awaiting send," "no reply,"
+or "quiet" item from the uncovered range. Set frontmatter `comms_coverage: partial`; otherwise use
+`complete` when every enabled comms source completed and `skipped` when Step 1b did not run. A
+disabled source's leftover digest never participates in this status.
 
 For outbound-contact tasks (reply/send/email/follow-up tasks), do **not** infer "awaiting send" from stale note state alone when email is enabled. Step 1b's live comms capture (or a same-day `Inbox/comms/<date>/` digest) is the prerequisite. If the connected-mailbox search missed the send but the task/person uses a non-connected sending account, render the item as "couldn't confirm from the connected mailbox — may have gone from <account>" and ask the user, rather than asserting it remains open. The connected-mailbox search can also be **stale** (the search index lags reality and a repeat search won't refresh it), so a send that search can't see is "couldn't confirm" even without a second account — verify the specific thread with a full-thread read (Gmail: `get_thread(threadId)`) before asserting anything, and never emit "awaiting send" / "unsent" off an empty search.
 

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -19,10 +19,15 @@ pre-flight — it relied on the user remembering; this reads the captured signal
 ## Hard rules (non-negotiable)
 
 - **The `## Action items` sections are the primary input.** Parse the phase-1 checkbox + `↳` blocks
-  from `Inbox/comms/<date>/*.md`. The prose sections (`## Summary`, `## Threads worth routing`,
-  `## Filtered as noise`) are context, not instructions. (One addition: the optional
+  from `Inbox/comms/<date>/*.md`. Parse `## Coverage` first: it is operational input, while the
+  prose sections (`## Summary`, `## Threads worth routing`, `## Filtered as noise`) are context,
+  not instructions. (One addition: the optional
   **calendar loop-closing** pass below contributes Tier-B proposals from vault Tasks whose linked
   calendar event has passed, when the `calendar` stream is enabled in `_config/sources.md`.)
+- **Coverage gaps are not negative evidence.** Action items that were captured remain usable, but
+  a `status: partial` digest can say nothing about its un-scanned range. Never infer "not sent,"
+  "no reply," or "quiet" from that absence. Carry every `coverage gap` through the report so the
+  user, phase 2, and the briefing all know which source, direction, and time range are inconclusive.
 - **Two tiers, and the line between them is firm** (see table). Auto-apply ONLY reversible CRM
   bookkeeping. Everything consequential, irreversible, sensitive, or needing a narrative is
   **proposed and held for explicit confirmation** — apply nothing in that tier until the user says
@@ -91,7 +96,9 @@ job, and the mark is the idempotency key. For each reconciled item:
 
 1. **Resolve the date + load the files.** Date = today (or the date arg). `ls Inbox/comms/<date>/`.
    If the folder is missing, tell the user to run [[capture-comms]] first and stop. Read every
-   `*.md` there; parse each `## Action items` block (checkbox + the `↳ signal / thread / likely
+   `*.md` there. Parse each `## Coverage` block first and collect every `status: partial` /
+   `coverage gap`; do not discard a partial file's positive signals. Then parse each
+   `## Action items` block (checkbox + the `↳ signal / thread / likely
    target / suggested action / confidence` fields — `thread` is the mail thread id (Gmail: `threadId`) for email
    items, used in Step 3 to confirm via `get_thread`). Read any existing `## Reconciliation` ledger.
 
@@ -139,9 +146,11 @@ job, and the mark is the idempotency key. For each reconciled item:
    <datetime> — agent:librarian — reconcile — Inbox/comms/<date>/ — reconcile-from-comms: <A> auto-applied, <C> confirmed+applied, <P> still-proposed, <S> skipped
    ```
 
-9. **Report back.** What was auto-applied, what's awaiting confirmation, what was routed to which
-   skill, and what was skipped (with the sensitive/uncertain reason). Offer the obvious follow-ons
-   (e.g. "want me to run [[capture-decision]] on the leadership meeting now?") but don't act unprompted.
+9. **Report back.** Lead with any capture coverage gaps, naming the source, direction, un-scanned
+   time range, and reason; state that absence-based conclusions there are inconclusive. Then say
+   what was auto-applied, what's awaiting confirmation, what was routed to which skill, and what
+   was skipped (with the sensitive/uncertain reason). Offer the obvious follow-ons (e.g. "want me
+   to run [[capture-decision]] on the leadership meeting now?") but don't act unprompted.
 
 ## Calendar loop-closing (gated on the `calendar` stream)
 
@@ -176,6 +185,9 @@ context:
   **§0 "State confirmation needed"** and owns the single batched confirmation in its
   report-back. When the user later confirms ("yes to 1,3,4"), route each through
   [[close-task]] / the owning skill and update this skill's ledger + checkboxes then.
+- **Hand every coverage gap back to the briefing too.** It persists `comms_coverage: partial`,
+  renders the exact source/range warning in §0, and repeats it in the chat report-back. Positive
+  captured signals can still reconcile; uncovered ranges remain explicitly inconclusive.
 
 Run standalone (direct `/reconcile-from-comms`), Step 6 stays interactive as written.
 

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -60,7 +60,8 @@ pre-flight — it relied on the user remembering; this reads the captured signal
 - **Delegate, don't reinvent.** Use the owning skill for each consequential mutation. The only
   changes you apply directly are the Tier-A bookkeeping fields (no skill wraps those).
 - **Idempotent.** Maintain a reconciliation ledger (see below) so a second run on the same day's
-  files never re-applies. If every action item is already reconciled, say so and stop.
+  files never re-applies. If every action item is already reconciled, skip comms-item processing;
+  still run the independently enabled calendar pass before reporting.
 
 ## The two tiers
 
@@ -101,8 +102,12 @@ job, and the mark is the idempotency key. For each reconciled item:
 
 1. **Resolve the date + load the enabled-source files.** Date = today (or the date arg). Read
    `_config/sources.md` and resolve the current enabled capture streams (older vault fallback:
-   email + Slack). Then `ls Inbox/comms/<date>/`. If the folder is missing, tell the user to run
-   [[capture-comms]] first and stop. **Ignore stale digests from disabled sources:** select only
+   email + Slack) plus the independently enabled calendar stream. When one or more capture streams
+   are enabled, `ls Inbox/comms/<date>/`; if the folder is missing, tell the user to run
+   [[capture-comms]] first and stop comms-item processing. If no capture streams are enabled, skip
+   the digest-folder requirement and comms-item processing, but continue to the calendar pass when
+   calendar is enabled. If neither capture nor calendar is enabled, report that there is nothing
+   to reconcile and stop. **Ignore stale digests from disabled sources:** select only
    files whose `source:` frontmatter is enabled, with the filename stem as the legacy fallback.
    Leave excluded files untouched. From the selected files, parse each `## Coverage` block first
    and collect every `status: partial` / `coverage gap`; do not discard a partial file's positive
@@ -152,7 +157,7 @@ job, and the mark is the idempotency key. For each reconciled item:
 8. **Log.** One `log.md` line summarizing the run (the per-change Tier-A lines from Step 5 are
    separate and already appended):
    ```
-   <datetime> — agent:librarian — reconcile — Inbox/comms/<date>/ — reconcile-from-comms: <A> auto-applied, <C> confirmed+applied, <P> still-proposed, <S> skipped
+   <datetime> — agent:librarian — reconcile — <Inbox/comms/<date>/ | calendar-only> — reconcile-from-comms: <A> auto-applied, <C> confirmed+applied, <P> still-proposed, <S> skipped
    ```
 
 9. **Report back.** Lead with any capture coverage gaps, naming the source, direction, un-scanned

--- a/packs/core/skills/reconcile-from-comms/SKILL.md
+++ b/packs/core/skills/reconcile-from-comms/SKILL.md
@@ -24,6 +24,11 @@ pre-flight — it relied on the user remembering; this reads the captured signal
   not instructions. (One addition: the optional
   **calendar loop-closing** pass below contributes Tier-B proposals from vault Tasks whose linked
   calendar event has passed, when the `calendar` stream is enabled in `_config/sources.md`.)
+- **Ignore stale digests from disabled sources.** Read the current enabled capture streams before
+  consuming the folder. Exclude a disabled source's entire file before parsing either
+  `## Coverage` or `## Action items`; do not apply its old items, propagate its gaps, update its
+  ledger, or delete it. Match `source:` frontmatter to `streams.<source>.enabled`, falling back to
+  the filename stem only for a legacy digest without `source:`.
 - **Coverage gaps are not negative evidence.** Action items that were captured remain usable, but
   a `status: partial` digest can say nothing about its un-scanned range. Never infer "not sent,"
   "no reply," or "quiet" from that absence. Carry every `coverage gap` through the report so the
@@ -94,10 +99,14 @@ job, and the mark is the idempotency key. For each reconciled item:
 
 ## Steps
 
-1. **Resolve the date + load the files.** Date = today (or the date arg). `ls Inbox/comms/<date>/`.
-   If the folder is missing, tell the user to run [[capture-comms]] first and stop. Read every
-   `*.md` there. Parse each `## Coverage` block first and collect every `status: partial` /
-   `coverage gap`; do not discard a partial file's positive signals. Then parse each
+1. **Resolve the date + load the enabled-source files.** Date = today (or the date arg). Read
+   `_config/sources.md` and resolve the current enabled capture streams (older vault fallback:
+   email + Slack). Then `ls Inbox/comms/<date>/`. If the folder is missing, tell the user to run
+   [[capture-comms]] first and stop. **Ignore stale digests from disabled sources:** select only
+   files whose `source:` frontmatter is enabled, with the filename stem as the legacy fallback.
+   Leave excluded files untouched. From the selected files, parse each `## Coverage` block first
+   and collect every `status: partial` / `coverage gap`; do not discard a partial file's positive
+   signals. Then parse each
    `## Action items` block (checkbox + the `↳ signal / thread / likely
    target / suggested action / confidence` fields — `thread` is the mail thread id (Gmail: `threadId`) for email
    items, used in Step 3 to confirm via `get_thread`). Read any existing `## Reconciliation` ledger.

--- a/packs/core/templates/briefing.md
+++ b/packs/core/templates/briefing.md
@@ -9,6 +9,8 @@ period_start: {{date}}
 period_end: {{date}}
 includes_calendar: true
 includes_agent_queue: true
+includes_comms: false
+comms_coverage: skipped
 open_tasks_count: 0
 projects_reviewed: 0
 sensitivity: private

--- a/packs/core/workflows/daily-briefing.md
+++ b/packs/core/workflows/daily-briefing.md
@@ -14,6 +14,13 @@ closes (plus passed calendar-event closes if the `calendar` stream is enabled) b
 numbered `## 0. State confirmation needed` section, confirmed in one batch. Skip this pass
 for backfilled briefings more than ~2 days old.
 
+Read every capture file's `## Coverage` before reconciliation. If any says `status: partial`,
+preserve the exact `coverage gap`, set briefing frontmatter `comms_coverage: partial`, and surface
+the warning at the top of §0 and the chat report-back. Positive captured signals remain usable;
+absence in an un-scanned source/direction/time range is inconclusive and must never become "not
+sent," "no reply," or "quiet." Use `comms_coverage: complete` only when every enabled comms source
+finished, and `skipped` when the pass did not run.
+
 When reading `_config/sources.md`, also respect `mailboxes.*`: the mail connector searches only
 `mailboxes.connected` (legacy vaults: `mailboxes.gmail_connected`). Forwarding-in addresses can make received mail visible, but sent
 mail from that address, or from `mailboxes.other_sending_accounts`, is invisible unless those

--- a/packs/core/workflows/daily-briefing.md
+++ b/packs/core/workflows/daily-briefing.md
@@ -8,8 +8,12 @@
 
 Before gathering the inputs below, run the default multi-source loop-closing pass (the
 skill version automates this; pasting the prompt, do it by hand): read `_config/sources.md`
-for enabled streams, run `capture-comms` (sent + received email/Slack) then
-`reconcile-from-comms` for today. Tier-A reversible bookkeeping auto-applies; Tier-B task
+for enabled streams and split capture streams (email, Slack, and future capture providers) from
+calendar, which is reconciliation-only. When at least one capture stream is enabled, run
+`capture-comms` (sent + received email/Slack) with only those streams, then run
+`reconcile-from-comms` for all enabled streams. When no capture streams are enabled, skip capture
+and stale digest parsing but still reconcile an enabled calendar; set `includes_comms: false` and
+`comms_coverage: skipped`. Tier-A reversible bookkeeping auto-applies; Tier-B task
 closes (plus passed calendar-event closes if the `calendar` stream is enabled) become the
 numbered `## 0. State confirmation needed` section, confirmed in one batch. Skip this pass
 for backfilled briefings more than ~2 days old.
@@ -20,8 +24,10 @@ items` parsing. Read `## Coverage` only from enabled-source files. If any says `
 preserve the exact `coverage gap`, set briefing frontmatter `comms_coverage: partial`, and surface
 the warning at the top of §0 and the chat report-back. Positive captured signals remain usable;
 absence in an un-scanned source/direction/time range is inconclusive and must never become "not
-sent," "no reply," or "quiet." Use `comms_coverage: complete` only when every enabled comms source
-finished, and `skipped` when the pass did not run.
+sent," "no reply," or "quiet." Set `includes_comms: true` only if at least one capture stream
+actually ran. Use `comms_coverage: complete` only when every enabled capture source finished,
+`partial` when at least one ran but an enabled capture source was incomplete, and `skipped` when
+no capture stream ran. Calendar reconciliation never counts as capture coverage.
 
 When reading `_config/sources.md`, also respect `mailboxes.*`: the mail connector searches only
 `mailboxes.connected` (legacy vaults: `mailboxes.gmail_connected`). Forwarding-in addresses can make received mail visible, but sent

--- a/packs/core/workflows/daily-briefing.md
+++ b/packs/core/workflows/daily-briefing.md
@@ -14,7 +14,9 @@ closes (plus passed calendar-event closes if the `calendar` stream is enabled) b
 numbered `## 0. State confirmation needed` section, confirmed in one batch. Skip this pass
 for backfilled briefings more than ~2 days old.
 
-Read every capture file's `## Coverage` before reconciliation. If any says `status: partial`,
+**Ignore stale digests from disabled sources:** before reconciliation, exclude their whole files
+by `source:` frontmatter (filename stem for legacy files) from both `## Coverage` and `## Action
+items` parsing. Read `## Coverage` only from enabled-source files. If any says `status: partial`,
 preserve the exact `coverage gap`, set briefing frontmatter `comms_coverage: partial`, and surface
 the warning at the top of §0 and the chat report-back. Positive captured signals remain usable;
 absence in an un-scanned source/direction/time range is inconclusive and must never become "not

--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -34,6 +34,15 @@ class TestCaptureCommsCoverageContract(unittest.TestCase):
         self.assertRegex(mail_step, r"(?i)paginate|pagination|cursor")
         self.assertRegex(mail_step, r"(?i)first page.*(?:not|never).*complete|never.*first page")
 
+    def test_mail_threads_are_deduplicated_across_the_whole_scan(self):
+        mail_step = numbered_step(self.skill, 3)
+        self.assertRegex(
+            mail_step,
+            r"(?is)threadId.{0,240}all (?:calendar-day )?slices.{0,240}query variants",
+        )
+        self.assertRegex(mail_step, r"(?is)read.{0,100}classif(?:y|ied).{0,100}once")
+        self.assertRegex(mail_step, r"(?is)preserv(?:e|ing).{0,120}(?:direction|provenance)")
+
     def test_incomplete_provider_scan_must_record_the_gap(self):
         write_step = numbered_step(self.skill, 6)
         self.assertRegex(write_step, r"(?i)every\s+enabled (?:source|stream)")
@@ -108,6 +117,31 @@ class TestCommsCoverageConsumers(unittest.TestCase):
             self.reconcile,
             r"(?is)disabled.{0,300}## Coverage.{0,160}## Action items|"
             r"## Coverage.{0,160}## Action items.{0,300}disabled",
+        )
+
+    def test_calendar_only_runs_skip_comms_coverage(self):
+        artifacts = {
+            "briefing": self.briefing,
+            "schema": self.briefing_schema,
+            "prompt": self.briefing_prompt,
+            "workflow": self.briefing_workflow,
+        }
+        skipped_without_capture = (
+            r"(?is)(?:no|zero) (?:enabled )?capture streams?.{0,240}"
+            r"comms_coverage.{0,80}skipped"
+        )
+        includes_actual_capture = (
+            r"(?is)includes_comms.{0,180}(?:at least one|any) capture stream"
+        )
+        for name, artifact in artifacts.items():
+            with self.subTest(artifact=name):
+                self.assertRegex(artifact, skipped_without_capture)
+                self.assertRegex(artifact, includes_actual_capture)
+
+        self.assertRegex(
+            self.reconcile,
+            r"(?is)no (?:enabled )?capture streams?.{0,240}"
+            r"(?:skip|do not require).{0,160}(?:digest|folder).{0,240}calendar",
         )
 
 

--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -87,6 +87,29 @@ class TestCommsCoverageConsumers(unittest.TestCase):
             r"(?is)## Coverage.*partial.*inconclusive",
         )
 
+    def test_disabled_source_digests_are_ignored_everywhere(self):
+        consumers = {
+            "capture handoff": (
+                ROOT / "packs/core/skills/capture-comms/SKILL.md"
+            ).read_text(),
+            "reconcile": self.reconcile,
+            "briefing": self.briefing,
+            "briefing prompt": self.briefing_prompt,
+            "briefing workflow": self.briefing_workflow,
+        }
+        disabled_filter = r"(?is)(?:ignore|exclude)[^.\n]{0,240}(?:disabled|not enabled)"
+        for name, artifact in consumers.items():
+            with self.subTest(consumer=name):
+                self.assertRegex(artifact, disabled_filter)
+
+        # Filtering applies to the whole stale digest, not coverage alone: old
+        # action items from a disabled source must not reconcile either.
+        self.assertRegex(
+            self.reconcile,
+            r"(?is)disabled.{0,300}## Coverage.{0,160}## Action items|"
+            r"## Coverage.{0,160}## Action items.{0,300}disabled",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -16,6 +16,14 @@ def numbered_step(skill: str, number: int) -> str:
     return match.group(0)
 
 
+def frontmatter_keys(document: str) -> set[str]:
+    """Return field names from the first YAML frontmatter example or document."""
+    match = re.search(r"(?ms)^---\n(.*?)^---$", document)
+    if match is None:
+        raise AssertionError("YAML frontmatter not found")
+    return set(re.findall(r"(?m)^([a-z][a-z0-9_]*):", match.group(1)))
+
+
 class TestCaptureCommsCoverageContract(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -63,6 +71,7 @@ class TestCommsCoverageConsumers(unittest.TestCase):
         cls.reconcile = (core / "skills/reconcile-from-comms/SKILL.md").read_text()
         cls.briefing = (core / "skills/daily-briefing/SKILL.md").read_text()
         cls.briefing_schema = (core / "schemas/briefing.md").read_text()
+        cls.briefing_template = (core / "templates/briefing.md").read_text()
         cls.briefing_prompt = (core / "prompts/daily-briefing.md").read_text()
         cls.briefing_workflow = (core / "workflows/daily-briefing.md").read_text()
 
@@ -95,6 +104,11 @@ class TestCommsCoverageConsumers(unittest.TestCase):
             self.briefing_workflow,
             r"(?is)## Coverage.*partial.*inconclusive",
         )
+
+    def test_installed_briefing_template_matches_schema_frontmatter(self):
+        schema_fields = frontmatter_keys(self.briefing_schema)
+        template_fields = frontmatter_keys(self.briefing_template)
+        self.assertEqual(set(), schema_fields - template_fields)
 
     def test_disabled_source_digests_are_ignored_everywhere(self):
         consumers = {

--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -1,0 +1,92 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def numbered_step(skill: str, number: int) -> str:
+    """Return one numbered skill step without coupling tests to line numbers."""
+    match = re.search(
+        rf"(?ms)^{number}\. \*\*.*?(?=^{number + 1}\. \*\*|\Z)", skill
+    )
+    if match is None:
+        raise AssertionError(f"step {number} not found")
+    return match.group(0)
+
+
+class TestCaptureCommsCoverageContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.skill = (
+            ROOT / "packs/core/skills/capture-comms/SKILL.md"
+        ).read_text()
+
+    def test_digest_has_explicit_coverage_section(self):
+        output_contract = self.skill.split("## Steps", 1)[0]
+        self.assertIn("## Coverage", output_contract)
+        self.assertRegex(output_contract, r"(?i)complete|coverage gap")
+
+    def test_mail_scan_covers_every_page_or_daily_slice(self):
+        mail_step = numbered_step(self.skill, 3)
+        self.assertRegex(mail_step, r"(?i)calendar[- ]day|per[- ]day|daily slices?")
+        self.assertRegex(mail_step, r"(?i)paginate|pagination|cursor")
+        self.assertRegex(mail_step, r"(?i)first page.*(?:not|never).*complete|never.*first page")
+
+    def test_incomplete_provider_scan_must_record_the_gap(self):
+        write_step = numbered_step(self.skill, 6)
+        self.assertRegex(write_step, r"(?i)every\s+enabled (?:source|stream)")
+        self.assertRegex(write_step, r"(?i)coverage gap")
+        self.assertRegex(write_step, r"(?i)unscanned|un-scanned")
+
+    def test_no_silent_caps_rule_applies_to_future_provider_scans(self):
+        hard_rules = self.skill.split("## Output shape", 1)[0]
+        self.assertRegex(hard_rules, r"(?i)no silent (?:caps|truncation)")
+        self.assertIn("Notion", hard_rules)
+        self.assertIn("Jira", hard_rules)
+
+
+class TestCommsCoverageConsumers(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        core = ROOT / "packs/core"
+        cls.reconcile = (core / "skills/reconcile-from-comms/SKILL.md").read_text()
+        cls.briefing = (core / "skills/daily-briefing/SKILL.md").read_text()
+        cls.briefing_schema = (core / "schemas/briefing.md").read_text()
+        cls.briefing_prompt = (core / "prompts/daily-briefing.md").read_text()
+        cls.briefing_workflow = (core / "workflows/daily-briefing.md").read_text()
+
+    def test_reconcile_treats_partial_capture_as_inconclusive(self):
+        self.assertIn("## Coverage", self.reconcile)
+        self.assertRegex(
+            self.reconcile,
+            r"(?is)coverage gap.*(?:not|never).*negative evidence",
+        )
+        briefing_mode = self.reconcile.split("## When invoked by daily-briefing", 1)[1]
+        self.assertRegex(briefing_mode, r"(?i)coverage gaps?.*briefing")
+
+    def test_briefing_persists_and_surfaces_partial_coverage(self):
+        for artifact in (
+            self.briefing,
+            self.briefing_schema,
+            self.briefing_prompt,
+        ):
+            self.assertIn("comms_coverage:", artifact)
+
+        self.assertRegex(
+            self.briefing,
+            r"(?is)coverage gap.*## 0\. State confirmation needed",
+        )
+        self.assertRegex(
+            self.briefing,
+            r"(?is)chat report-back.*coverage (?:gap|is partial)",
+        )
+        self.assertRegex(
+            self.briefing_workflow,
+            r"(?is)## Coverage.*partial.*inconclusive",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- split multi-day communication searches into bounded daily slices and paginate every slice to exhaustion
- deduplicate mail threads globally across slices, pages, directions, and query variants before full-thread classification
- add an explicit `## Coverage` contract with complete/partial status and precise un-scanned ranges
- propagate partial coverage through reconciliation and daily briefings so missing results remain inconclusive
- report calendar-only reconciliation as skipped comms coverage while still processing passed events
- apply the no-silent-caps rule to vault-specific providers such as Notion and Jira
- add contract-level regression tests for capture and downstream consumers

## Root cause

`capture-comms` could treat a provider's first newest-first result page as complete coverage. Mail had no pagination or multi-day slicing requirement, duplicate thread hits could cross slices, and interrupted or calendar-only runs had no reliable structured coverage accounting.

## Impact

Long scan windows no longer silently omit earlier days or emit duplicate actions for the same thread. When a provider cannot finish, successful hits remain usable while the exact uncovered source, direction, and time range are surfaced to the user instead of becoming false negative evidence. Calendar reconciliation can still run independently without claiming that comms were scanned.

## Validation

- `cd tools && python3 -m unittest discover -p 'test_*.py' -v` — 62 passed
- `python3 tools/audit_refs.py .` — clean
- `python3 tools/audit_literals.py ./packs` — clean
- `git diff --check` — clean

Known unrelated baseline failure: `tests/test_init.sh` still expects the legacy `gmail_connected` key while the current generator emits `connected`.

Fixes #39