### PR TITLE
Add customizable vault tabs

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -79,7 +79,10 @@ driving a packaged build, including how to test auto-update.
 
 ## Customizing tabs & quick-actions
 
-The right panel's tabs *and* the quick-action chips are user-customizable, the Memex way — as a plain
+The right panel starts with a curated set of frequently used tabs. Use the **gear beside the tab bar**
+to hide any of those defaults or add any other folder in the vault; choices are stored per vault.
+
+Tabs *and* the quick-action chips are also user-customizable, the Memex way — as a plain
 vault file the agent maintains, `_config/desktop-tabs.json`. You don't edit it by hand: just ask the
 agent ("add a CV tab", "add a tab for my p1 tasks", "embed my dashboards", "add a Blockers shortcut")
 and it writes the file. The app watches `_config/` and **rebuilds live** — no restart, no refresh.
@@ -95,6 +98,18 @@ and it writes the file. The app watches `_config/` and **rebuilds live** — no 
   "chips": [
     { "label": "Blockers", "prompt": "What's blocked right now and why?" }
   ]
+}
+```
+
+The gear stores its choices in the same file under `navigation`, while preserving tabs, chips, and
+other settings:
+
+```json
+{
+  "navigation": {
+    "hidden": ["ideas"],
+    "folders": ["Atlas/Areas", "Ops/Briefings"]
+  }
 }
 ```
 

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -42,9 +42,9 @@ Keep your chat replies short and conversational — a sentence or two saying wha
 
 This is the user's own Memex vault. Follow AGENTS.md / CLAUDE.md, use the vault's skills, and keep notes schema-conformant.
 
-CUSTOM TABS & CHIPS: The right panel's tabs and the quick-action chips above the message box are user-customizable via the vault file \`_config/desktop-tabs.json\`. When the user asks to add/rename/remove/repoint a tab or add a quick-action, create or edit that file (preserve existing entries). Changes apply live — never tell the user to restart or refresh.
+CUSTOM TABS & CHIPS: The right panel's tabs and the quick-action chips above the message box are user-customizable via the vault file \`_config/desktop-tabs.json\`. When the user asks to add/rename/remove/repoint a tab or add a quick-action, create or edit that file. Preserve the existing \`navigation\` object (the gear menu's per-vault visibility/folder choices), the other tabs and chips, and any unknown fields. Changes apply live — never tell the user to restart or refresh.
 
-Shape: {"tabs":[ ... ], "chips":[ ... ]}.
+Shape: {"tabs":[ ... ], "chips":[ ... ], "navigation":{"hidden":[ ... ], "folders":[ ... ]}}.
 
 Each tab has a short lowercase unique \`id\` (never dashboard/tasks/projects/ideas/people/inbox/outbox/artifact) and a display \`label\`, plus ONE of:
 - \`"path"\`: a vault-relative path to a folder (browsable file list) or a single file (rendered). e.g. {"id":"cv","label":"CV","path":"CV"}.

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -26,6 +26,13 @@ import { buildWikiIndex } from './wiki-index';
 import { SerialQueue } from './serial-queue';
 import { unpackedClaudeBinaryPath } from './claude-binary';
 import { acceptanceRecord, loadLegal, needsAcceptance, type LegalDocs, type TermsAcceptance } from './legal';
+import {
+  parseDesktopTabsDocument,
+  tabPreferencesFromDocument,
+  withTabPreferences,
+  writeDesktopTabsDocument,
+  type DesktopTabsDocument,
+} from './tab-preferences';
 
 const fsp = fs.promises;
 // Development runs inside the engine checkout; packaged builds carry the exact
@@ -174,6 +181,88 @@ function filterRows<T extends FilterableRow>(rows: T[], where: QueryWhere | null
     if (source === 'tasks' && w.exclude_done !== false && !w.status && done.has(r.status || '')) return false;
     return true;
   });
+}
+
+const BUILTIN_TAB_IDS = new Set(['dashboard', 'tasks', 'projects', 'ideas', 'people', 'inbox', 'outbox']);
+const BUILTIN_TAB_PATHS = new Set(['Ops/Tasks', 'Atlas/Projects', 'Atlas/Ideas', 'Atlas/People', 'Inbox', 'outputs']);
+
+// desktop-tabs.json is hand-editable: accept a scalar where the schema wants an
+// array (e.g. "status": "next"), else the filter silently matches nothing.
+function normalizeWhere(w: unknown): QueryWhere | null {
+  if (!w || typeof w !== 'object') return null;
+  const out = { ...(w as QueryWhere) } as Record<string, unknown>;
+  for (const k of ['status', 'priority']) {
+    if (out[k] != null && !Array.isArray(out[k])) out[k] = [String(out[k])];
+  }
+  return out as QueryWhere;
+}
+
+function readDesktopTabsDocument(vault: string, strict = false): DesktopTabsDocument {
+  const relative = path.join('_config', 'desktop-tabs.json');
+  const file = vaultLib.readFile(vault, relative);
+  if (!file || file.kind !== 'text') {
+    if (strict && fs.existsSync(path.join(vault, relative))) throw new Error('desktop-tabs.json is not a safe readable file');
+    return {};
+  }
+  try {
+    return parseDesktopTabsDocument(file.content || '');
+  } catch (error) {
+    if (strict) throw error;
+    return {};
+  }
+}
+
+function appConfigFromDocument(vault: string, document: DesktopTabsDocument): AppConfig {
+  const out: AppConfig = { tabs: [], chips: [], hiddenTabs: [], folders: [], availableFolders: [] };
+  const cfg = document as { tabs?: unknown[]; chips?: unknown[] };
+  if (Array.isArray(cfg.tabs)) {
+    const seen = new Set<string>();
+    out.tabs = cfg.tabs
+      .map((t) => {
+        const tab = t as Partial<TabDef> & { id?: unknown; label?: unknown };
+        if (!tab || !tab.label) return null;
+        // no id: derive one from the label rather than silently dropping the tab
+        const id = String(tab.id || String(tab.label).toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/(^-+|-+$)/g, ''));
+        return id ? { ...tab, id } : null;
+      })
+      .filter((t): t is Partial<TabDef> & { id: string; label: string } =>
+        !!t && !BUILTIN_TAB_IDS.has(t.id.toLowerCase()) && !t.id.startsWith('folder:') && !seen.has(t.id) && !!seen.add(t.id))
+      .map((t) => {
+        const url = t.url ? String(t.url) : '';
+        return {
+          id: String(t.id),
+          label: String(t.label),
+          kind: (t.kind || (url ? 'web' : (t.source ? 'query' : 'path'))) as TabDef['kind'],
+          path: t.path ? String(t.path) : '',
+          url: url && isSafeExternalUrl(url) ? url : '',
+          source: t.source ? String(t.source) : '',
+          where: normalizeWhere(t.where),
+          empty: t.empty ? String(t.empty) : '',
+        };
+      })
+      .slice(0, 12);
+  }
+  if (Array.isArray(cfg.chips)) {
+    out.chips = (cfg.chips as Array<Partial<ChipDef>>)
+      .filter((c) => !!(c && c.label && c.prompt))
+      .map((c) => ({ label: String(c.label), prompt: String(c.prompt) }))
+      .slice(0, 12);
+  }
+
+  const representedPaths = new Set(BUILTIN_TAB_PATHS);
+  for (const tab of out.tabs) {
+    if (tab.kind === 'path' && tab.path) representedPaths.add(tab.path.replace(/\\/g, '/').replace(/^\/+|\/+$/g, ''));
+  }
+  // Bound renderer work for pathological vaults; the preference format itself is capped lower.
+  out.availableFolders = vaultLib.listFolders(vault).filter((folder) => !representedPaths.has(folder)).slice(0, 1000);
+  const preferences = tabPreferencesFromDocument(document, [...BUILTIN_TAB_IDS, ...out.tabs.map((tab) => tab.id)], out.availableFolders);
+  out.hiddenTabs = preferences.hiddenTabs;
+  out.folders = preferences.folders;
+  return out;
+}
+
+function readAppConfig(vault: string): AppConfig {
+  return appConfigFromDocument(vault, readDesktopTabsDocument(vault));
 }
 
 // ---------- markdown -> safe html ----------
@@ -971,62 +1060,28 @@ function registerIpc(): void {
     }
   });
 
-  // desktop-tabs.json is hand-editable: accept a scalar where the schema wants an
-  // array (e.g. "status": "next"), else the filter silently matches nothing.
-  function normalizeWhere(w: unknown): QueryWhere | null {
-    if (!w || typeof w !== 'object') return null;
-    const out = { ...(w as QueryWhere) } as Record<string, unknown>;
-    for (const k of ['status', 'priority']) {
-      if (out[k] != null && !Array.isArray(out[k])) out[k] = [String(out[k])];
-    }
-    return out as QueryWhere;
-  }
-
   handle('data:appConfig', async (): Promise<AppConfig> => {
-    const out: AppConfig = { tabs: [], chips: [] };
     const vault = activeVaultPath();
-    if (!vault) return out;
-    const builtins = new Set(['dashboard', 'tasks', 'projects', 'ideas', 'people', 'inbox', 'outbox', 'artifact']);
-    try {
-      const file = vaultLib.readFile(vault, path.join('_config', 'desktop-tabs.json'));
-      if (!file || file.kind !== 'text') return out;
-      const raw = file.content || '';
-      const cfg = JSON.parse(raw) as { tabs?: unknown[]; chips?: unknown[] };
-      if (Array.isArray(cfg.tabs)) {
-        const seen = new Set<string>();
-        out.tabs = cfg.tabs
-          .map((t) => {
-            const tab = t as Partial<TabDef> & { id?: unknown; label?: unknown };
-            if (!tab || !tab.label) return null;
-            // no id: derive one from the label rather than silently dropping the tab
-            const id = String(tab.id || String(tab.label).toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/(^-+|-+$)/g, ''));
-            return id ? { ...tab, id } : null;
-          })
-          .filter((t): t is Partial<TabDef> & { id: string; label: string } =>
-            !!t && !builtins.has(t.id.toLowerCase()) && !seen.has(t.id) && !!seen.add(t.id))
-          .map((t) => {
-            const url = t.url ? String(t.url) : '';
-            return {
-              id: String(t.id),
-              label: String(t.label),
-              kind: (t.kind || (url ? 'web' : (t.source ? 'query' : 'path'))) as TabDef['kind'],
-              path: t.path ? String(t.path) : '',
-              url: url && isSafeExternalUrl(url) ? url : '',
-              source: t.source ? String(t.source) : '',
-              where: normalizeWhere(t.where),
-              empty: t.empty ? String(t.empty) : '',
-            };
-          })
-          .slice(0, 12);
-      }
-      if (Array.isArray(cfg.chips)) {
-        out.chips = (cfg.chips as Array<Partial<ChipDef>>)
-          .filter((c) => !!(c && c.label && c.prompt))
-          .map((c) => ({ label: String(c.label), prompt: String(c.prompt) }))
-          .slice(0, 12);
-      }
-    } catch (_) {}
-    return out;
+    return vault ? readAppConfig(vault) : { tabs: [], chips: [], hiddenTabs: [], folders: [], availableFolders: [] };
+  });
+
+  handle('tabs:updatePreferences', async (_e, input: TabPreferenceUpdate): Promise<AppConfig> => {
+    const vault = activeVaultPath();
+    if (!vault) throw new Error('No vault is open');
+    const currentDocument = readDesktopTabsDocument(vault, true);
+    const current = appConfigFromDocument(vault, currentDocument);
+    const nextDocument = withTabPreferences(
+      currentDocument,
+      input,
+      [...BUILTIN_TAB_IDS, ...current.tabs.map((tab) => tab.id)],
+      current.availableFolders,
+    );
+    const createdConfigDirectory = writeDesktopTabsDocument(vault, nextDocument);
+    // On platforms without recursive root watching, a missing _config directory
+    // was skipped when the vault opened. Attach the fallback watcher now that the
+    // picker created it so later agent/manual edits still rebuild the tab bar live.
+    if (createdConfigDirectory) startWatchers(vault);
+    return appConfigFromDocument(vault, nextDocument);
   });
 
   handle('tab:query', async (_e, def: TabDef | null): Promise<TabQueryResult> => {

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -27,6 +27,8 @@ import { SerialQueue } from './serial-queue';
 import { unpackedClaudeBinaryPath } from './claude-binary';
 import { acceptanceRecord, loadLegal, needsAcceptance, type LegalDocs, type TermsAcceptance } from './legal';
 import {
+  CONFIGURABLE_BUILTIN_TAB_IDS,
+  isReservedDesktopTabId,
   parseDesktopTabsDocument,
   tabPreferencesFromDocument,
   withTabPreferences,
@@ -183,7 +185,7 @@ function filterRows<T extends FilterableRow>(rows: T[], where: QueryWhere | null
   });
 }
 
-const BUILTIN_TAB_IDS = new Set(['dashboard', 'tasks', 'projects', 'ideas', 'people', 'inbox', 'outbox']);
+const BUILTIN_TAB_IDS = new Set<string>(CONFIGURABLE_BUILTIN_TAB_IDS);
 const BUILTIN_TAB_PATHS = new Set(['Ops/Tasks', 'Atlas/Projects', 'Atlas/Ideas', 'Atlas/People', 'Inbox', 'outputs']);
 
 // desktop-tabs.json is hand-editable: accept a scalar where the schema wants an
@@ -226,7 +228,7 @@ function appConfigFromDocument(vault: string, document: DesktopTabsDocument): Ap
         return id ? { ...tab, id } : null;
       })
       .filter((t): t is Partial<TabDef> & { id: string; label: string } =>
-        !!t && !BUILTIN_TAB_IDS.has(t.id.toLowerCase()) && !t.id.startsWith('folder:') && !seen.has(t.id) && !!seen.add(t.id))
+        !!t && !isReservedDesktopTabId(t.id) && !seen.has(t.id) && !!seen.add(t.id))
       .map((t) => {
         const url = t.url ? String(t.url) : '';
         return {

--- a/app/src/main/tab-preferences.ts
+++ b/app/src/main/tab-preferences.ts
@@ -4,6 +4,21 @@ import { pathType } from './vault';
 
 export interface DesktopTabsDocument { [key: string]: unknown; }
 
+export const CONFIGURABLE_BUILTIN_TAB_IDS = [
+  'dashboard', 'tasks', 'projects', 'ideas', 'people', 'inbox', 'outbox',
+] as const;
+
+const RESERVED_DESKTOP_TAB_IDS = new Set<string>([
+  ...CONFIGURABLE_BUILTIN_TAB_IDS,
+  'artifact',
+]);
+
+/** Reject IDs owned by renderer views and the namespace used for generated folder tabs. */
+export function isReservedDesktopTabId(id: string): boolean {
+  const normalized = String(id || '').toLowerCase();
+  return RESERVED_DESKTOP_TAB_IDS.has(normalized) || normalized.startsWith('folder:');
+}
+
 interface NavigationDocument {
   hidden?: unknown;
   folders?: unknown;

--- a/app/src/main/tab-preferences.ts
+++ b/app/src/main/tab-preferences.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { pathType } from './vault';
+
+export interface DesktopTabsDocument { [key: string]: unknown; }
+
+interface NavigationDocument {
+  hidden?: unknown;
+  folders?: unknown;
+}
+
+const MAX_PREFERENCE_ITEMS = 100;
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean);
+}
+
+export function parseDesktopTabsDocument(raw: string): DesktopTabsDocument {
+  if (!raw.trim()) return {};
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('desktop-tabs.json must contain a JSON object');
+  return parsed as DesktopTabsDocument;
+}
+
+export function tabPreferencesFromDocument(
+  document: DesktopTabsDocument,
+  allowedTabIds: Iterable<string>,
+  availableFolders: Iterable<string>,
+): TabPreferenceUpdate {
+  const navigation = document.navigation && typeof document.navigation === 'object' && !Array.isArray(document.navigation)
+    ? document.navigation as NavigationDocument
+    : {};
+  const allowedList = Array.from(allowedTabIds, String);
+  const allowed = new Set(allowedList);
+  const available = new Set(Array.from(availableFolders, String));
+  let hiddenTabs = Array.from(new Set(stringList(navigation.hidden).filter((id) => allowed.has(id)))).slice(0, MAX_PREFERENCE_ITEMS);
+  const folders = Array.from(new Set(stringList(navigation.folders).filter((folder) => available.has(folder)))).slice(0, MAX_PREFERENCE_ITEMS);
+  // Hand-edited config should not strand the panel with no way back to a view.
+  // The UI also enforces this, but the file remains intentionally editable.
+  if (!folders.length && allowedList.length && allowedList.every((id) => hiddenTabs.includes(id))) {
+    hiddenTabs = hiddenTabs.filter((id) => id !== allowedList[0]);
+  }
+  return {
+    hiddenTabs,
+    folders,
+  };
+}
+
+export function withTabPreferences(
+  document: DesktopTabsDocument,
+  input: TabPreferenceUpdate,
+  allowedTabIds: Iterable<string>,
+  availableFolders: Iterable<string>,
+): DesktopTabsDocument {
+  const normalized = tabPreferencesFromDocument(
+    { navigation: { hidden: input?.hiddenTabs, folders: input?.folders } },
+    allowedTabIds,
+    availableFolders,
+  );
+  const existingNavigation = document.navigation && typeof document.navigation === 'object' && !Array.isArray(document.navigation)
+    ? document.navigation as NavigationDocument
+    : {};
+  return {
+    ...document,
+    navigation: {
+      ...existingNavigation,
+      hidden: normalized.hiddenTabs,
+      folders: normalized.folders,
+    },
+  };
+}
+
+/** Atomically replace only the known desktop-tabs file inside a validated vault config directory. */
+export function writeDesktopTabsDocument(vault: string, document: DesktopTabsDocument): boolean {
+  const configType = pathType(vault, '_config');
+  const configDir = path.join(vault, '_config');
+  let createdConfigDirectory = false;
+  if (configType && configType !== 'directory') throw new Error('The vault _config path is not a directory');
+  if (!configType) {
+    if (fs.existsSync(configDir)) throw new Error('The vault _config directory is unsafe');
+    fs.mkdirSync(configDir, { recursive: false });
+    createdConfigDirectory = true;
+  }
+  const target = path.join(configDir, 'desktop-tabs.json');
+  if (fs.existsSync(target) && pathType(vault, '_config/desktop-tabs.json') !== 'file') {
+    throw new Error('desktop-tabs.json is unsafe');
+  }
+  const temporary = path.join(configDir, `.desktop-tabs-${process.pid}-${Date.now()}.tmp`);
+  try {
+    fs.writeFileSync(temporary, JSON.stringify(document, null, 2) + '\n', { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+    fs.renameSync(temporary, target);
+  } finally {
+    try { if (fs.existsSync(temporary)) fs.unlinkSync(temporary); } catch (_) {}
+  }
+  return createdConfigDirectory;
+}

--- a/app/src/main/vault.ts
+++ b/app/src/main/vault.ts
@@ -334,6 +334,29 @@ export function listFolder(vault: string, relDir: string): FileEntry[] {
   return acc;
 }
 
+const HIDDEN_FOLDER_NAMES = new Set(['node_modules', 'dist', 'release']);
+
+/** List user-facing vault folders without exposing hidden/configuration trees or symlinks. */
+export function listFolders(vault: string, maxDepth = 4): string[] {
+  const folders: string[] = [];
+  const walkFolders = (relDir: string, depth: number): void => {
+    if (depth > maxDepth || folders.length >= MAX_DIRECTORY_ENTRIES) return;
+    const full = relDir ? path.join(vault, relDir) : vault;
+    for (const ent of safeList(full)) {
+      if (folders.length >= MAX_DIRECTORY_ENTRIES) return;
+      if (!ent.isDirectory() || ent.isSymbolicLink() || ent.name.startsWith('.') || ent.name.startsWith('_') || HIDDEN_FOLDER_NAMES.has(ent.name)) continue;
+      const rel = relDir ? path.join(relDir, ent.name) : ent.name;
+      if (pathType(vault, rel) !== 'directory') continue;
+      // Store portable slash-separated paths in the vault config, including on Windows.
+      const portable = rel.split(path.sep).join('/');
+      folders.push(portable);
+      walkFolders(rel, depth + 1);
+    }
+  };
+  walkFolders('', 1);
+  return folders.sort((a, b) => a.localeCompare(b));
+}
+
 export function latestBriefing(vault: string): BriefingInfo | null {
   const dir = path.join(vault, 'Ops/Briefings');
   if (pathType(vault, 'Ops/Briefings') !== 'directory') return null;

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -32,6 +32,7 @@ const api: MemexApi = {
   // data panels
   data: (kind: DataKind) => invoke('data:get', kind),
   appConfig: () => invoke('data:appConfig'),
+  updateTabPreferences: (preferences) => invoke('tabs:updatePreferences', preferences),
   search: (q) => invoke('vault:search', q),
   tabContent: (p) => invoke('tab:content', p),
   tabQuery: (def) => invoke('tab:query', def),

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -96,15 +96,32 @@
         </button>
       </div>
       <nav class="tabs" id="tabs">
-        <button class="tab active" data-tab="dashboard">Dashboard</button>
-        <button class="tab" data-tab="tasks">Tasks <span class="tab-count" id="cntTasks"></span></button>
-        <button class="tab" data-tab="projects">Projects <span class="tab-count" id="cntProjects"></span></button>
-        <button class="tab" data-tab="ideas">Ideas <span class="tab-count" id="cntIdeas"></span></button>
-        <button class="tab" data-tab="people">People <span class="tab-count" id="cntPeople"></span></button>
-        <button class="tab" data-tab="inbox">Inbox <span class="tab-count badge" id="cntInbox"></span></button>
-        <button class="tab" data-tab="outbox">Outbox <span class="tab-count" id="cntOutputs"></span></button>
+        <button class="tab active" data-tab="dashboard" data-builtin="1">Dashboard</button>
+        <button class="tab" data-tab="tasks" data-builtin="1">Tasks <span class="tab-count" id="cntTasks"></span></button>
+        <button class="tab" data-tab="projects" data-builtin="1">Projects <span class="tab-count" id="cntProjects"></span></button>
+        <button class="tab" data-tab="ideas" data-builtin="1">Ideas <span class="tab-count" id="cntIdeas"></span></button>
+        <button class="tab" data-tab="people" data-builtin="1">People <span class="tab-count" id="cntPeople"></span></button>
+        <button class="tab" data-tab="inbox" data-builtin="1">Inbox <span class="tab-count badge" id="cntInbox"></span></button>
+        <button class="tab" data-tab="outbox" data-builtin="1">Outbox <span class="tab-count" id="cntOutputs"></span></button>
         <button class="tab tab-artifact" data-tab="artifact" id="artifactTab" style="display:none">Artifact<span class="tab-close" id="artifactClose" title="Close artifact">×</span></button>
       </nav>
+      <div class="tab-settings" id="tabSettings">
+        <button class="tab-settings-toggle" id="tabSettingsToggle" type="button" title="Choose tabs" aria-label="Choose tabs" aria-haspopup="dialog" aria-expanded="false">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 00.3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 00-1.9-.3 1.7 1.7 0 00-1 1.6v.2h-4V21a1.7 1.7 0 00-1-1.6 1.7 1.7 0 00-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 00.3-1.9A1.7 1.7 0 003 14H2.8v-4H3a1.7 1.7 0 001.6-1 1.7 1.7 0 00-.3-1.9L4.2 7 7 4.2l.1.1a1.7 1.7 0 001.9.3A1.7 1.7 0 0010 3v-.2h4V3a1.7 1.7 0 001 1.6 1.7 1.7 0 001.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 00-.3 1.9 1.7 1.7 0 001.6 1h.2v4H21a1.7 1.7 0 00-1.6 1z"/></svg>
+        </button>
+        <form class="tab-settings-popover" id="tabSettingsPopover" role="dialog" aria-label="Choose tabs" hidden>
+          <div class="tab-settings-head">
+            <div><strong>Choose tabs</strong><span>Keep the essentials, add any vault folders you use.</span></div>
+            <button class="tab-settings-close" id="tabSettingsClose" type="button" aria-label="Close tab chooser">×</button>
+          </div>
+          <div class="tab-settings-options" id="tabSettingsOptions"></div>
+          <div class="tab-settings-foot">
+            <button class="tab-settings-reset" id="tabSettingsReset" type="button">Restore defaults</button>
+            <span class="tab-settings-status" id="tabSettingsStatus" aria-live="polite"></span>
+            <button class="btn tiny" id="tabSettingsSave" type="submit">Done</button>
+          </div>
+        </form>
+      </div>
       </div>
       <div class="panel-body" id="panelBody"></div>
     </section>

--- a/app/src/renderer/renderer.ts
+++ b/app/src/renderer/renderer.ts
@@ -271,9 +271,11 @@ async function loadAppConfig(expectedEpoch = vaultEpoch): Promise<void> {
 }
 
 function firstVisibleTab(): string | null {
-  const button = Array.from(document.querySelectorAll<HTMLElement>('.tab[data-tab]'))
-    .find((candidate) => candidate.id !== 'artifactTab' && candidate.style.display !== 'none');
-  return button?.dataset.tab || null;
+  return selectFirstVisibleTab(Array.from(document.querySelectorAll<HTMLElement>('.tab[data-tab]')).map((button) => ({
+    tab: button.dataset.tab || '',
+    visible: button.style.display !== 'none',
+    artifact: button.id === 'artifactTab',
+  })));
 }
 
 function visibleTab(tab: string): boolean {
@@ -1301,7 +1303,7 @@ function closeArtifact(): void {
   currentArtifact = null;
   state.hasArtifact = false;
   $('artifactTab').style.display = 'none';
-  if (state.tab === 'artifact') switchTab('dashboard');
+  if (state.tab === 'artifact') switchTab(firstVisibleTab() || 'dashboard');
 }
 $('artifactClose').onclick = (e) => { e.stopPropagation(); closeArtifact(); };
 

--- a/app/src/renderer/renderer.ts
+++ b/app/src/renderer/renderer.ts
@@ -35,7 +35,11 @@ interface UIState {
   history: HistoryEntry[];
   histPos: number;
   customTabs: TabDef[];
+  configuredTabs: TabDef[];
   customChips: ChipDef[];
+  hiddenTabs: string[];
+  selectedFolders: string[];
+  availableFolders: string[];
 }
 
 const state: UIState = {
@@ -48,8 +52,22 @@ const state: UIState = {
   history: [],
   histPos: -1,
   customTabs: [],
+  configuredTabs: [],
   customChips: [],
+  hiddenTabs: [],
+  selectedFolders: [],
+  availableFolders: [],
 };
+
+const BUILTIN_TABS = [
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'ideas', label: 'Ideas' },
+  { id: 'people', label: 'People' },
+  { id: 'inbox', label: 'Inbox' },
+  { id: 'outbox', label: 'Outbox' },
+] as const;
 let vaultOpening = false;
 let vaultEpoch = 0;
 const vaultOpenEpochs: VaultOpenEpochState = { request: 0, epoch: 0 };
@@ -180,7 +198,7 @@ async function openVault(p: string): Promise<void> {
       flashChat('⚠ Could not load this vault\'s desktop tabs: ' + String((error as Error)?.message || error));
     }
     if (request !== vaultOpenEpochs.request) return;
-    switchTab('dashboard');
+    switchTab(firstVisibleTab() || 'dashboard');
     if (res.warning) flashChat('⚠ ' + res.warning);
     if (res.pendingDrop) reportIconDrop(res.pendingDrop.copied || [], res.pendingDrop.error);
     // Surface a stale vault engine without making the user open the switcher.
@@ -207,15 +225,34 @@ async function openVault(p: string): Promise<void> {
 }
 
 async function loadAppConfig(expectedEpoch = vaultEpoch): Promise<void> {
-  const cfg = (await M.appConfig()) || { tabs: [], chips: [] };
+  const cfg = (await M.appConfig()) || { tabs: [], chips: [], hiddenTabs: [], folders: [], availableFolders: [] };
   if (expectedEpoch !== vaultEpoch) return;
-  state.customTabs = cfg.tabs || [];
+  state.configuredTabs = cfg.tabs || [];
+  state.hiddenTabs = cfg.hiddenTabs || [];
+  state.selectedFolders = cfg.folders || [];
+  state.availableFolders = cfg.availableFolders || [];
+  const folderTabs: TabDef[] = state.selectedFolders.map((folder) => ({
+    id: `folder:${folder}`,
+    label: folder.split('/').filter(Boolean).pop() || folder,
+    kind: 'path',
+    path: folder,
+    url: '',
+    source: '',
+    where: null,
+    empty: '',
+  }));
+  state.customTabs = [...state.configuredTabs, ...folderTabs];
   state.customChips = cfg.chips || [];
+  document.querySelectorAll<HTMLElement>('.tab[data-builtin="1"]').forEach((button) => {
+    button.style.display = state.hiddenTabs.includes(button.dataset.tab || '') ? 'none' : '';
+  });
   // rebuild custom tab buttons
   document.querySelectorAll('.tab[data-custom="1"]').forEach((b) => b.remove());
   const artifactTab = $('artifactTab');
   for (const def of state.customTabs) {
-    const b = el('button', 'tab tab-custom');
+    if (state.hiddenTabs.includes(def.id)) continue;
+    const isFolder = def.id.startsWith('folder:');
+    const b = el('button', isFolder ? 'tab tab-folder' : 'tab tab-custom');
     b.textContent = def.label;
     b.dataset.tab = def.id;
     b.dataset.custom = '1';
@@ -230,7 +267,139 @@ async function loadAppConfig(expectedEpoch = vaultEpoch): Promise<void> {
     b.dataset.custom = '1';
     $('chips').appendChild(b);
   }
+  renderTabSettingsOptions();
 }
+
+function firstVisibleTab(): string | null {
+  const button = Array.from(document.querySelectorAll<HTMLElement>('.tab[data-tab]'))
+    .find((candidate) => candidate.id !== 'artifactTab' && candidate.style.display !== 'none');
+  return button?.dataset.tab || null;
+}
+
+function visibleTab(tab: string): boolean {
+  const button = document.querySelector<HTMLElement>(`.tab[data-tab="${CSS.escape(tab)}"]`);
+  return !!button && button.style.display !== 'none';
+}
+
+interface TabSettingsOption {
+  kind: 'tab' | 'folder';
+  value: string;
+  label: string;
+  detail?: string;
+  checked: boolean;
+}
+
+function addTabSettingsGroup(title: string, options: TabSettingsOption[]): void {
+  if (!options.length) return;
+  const container = $('tabSettingsOptions');
+  container.appendChild(textEl('div', 'tab-settings-group-title', title));
+  for (const option of options) {
+    const row = el('label', 'tab-settings-option');
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = option.checked;
+    input.dataset.kind = option.kind;
+    input.dataset.value = option.value;
+    row.appendChild(input);
+    const main = el('span', 'tab-settings-option-main');
+    main.appendChild(textEl('span', 'tab-settings-option-name', option.label));
+    if (option.detail) main.appendChild(textEl('span', 'tab-settings-option-path', option.detail));
+    row.appendChild(main);
+    container.appendChild(row);
+  }
+}
+
+function renderTabSettingsOptions(): void {
+  const container = $('tabSettingsOptions');
+  container.innerHTML = '';
+  addTabSettingsGroup('Essentials', BUILTIN_TABS.map((tab) => ({
+    kind: 'tab', value: tab.id, label: tab.label, checked: !state.hiddenTabs.includes(tab.id),
+  })));
+  addTabSettingsGroup('Custom tabs', state.configuredTabs.map((tab) => ({
+    kind: 'tab', value: tab.id, label: tab.label,
+    detail: tab.kind === 'path' ? tab.path : tab.kind === 'query' ? `${tab.source || 'tasks'} query` : tab.url,
+    checked: !state.hiddenTabs.includes(tab.id),
+  })));
+  const selected = new Set(state.selectedFolders);
+  addTabSettingsGroup('Vault folders', state.availableFolders.map((folder) => ({
+    kind: 'folder', value: folder,
+    label: folder.split('/').filter(Boolean).pop() || folder,
+    detail: folder,
+    checked: selected.has(folder),
+  })));
+  if (!state.availableFolders.length) {
+    container.appendChild(textEl('div', 'tab-settings-empty', 'No additional vault folders are available yet.'));
+  }
+}
+
+function closeTabSettings(): void {
+  const popover = $('tabSettingsPopover') as HTMLFormElement;
+  popover.hidden = true;
+  $('tabSettingsToggle').setAttribute('aria-expanded', 'false');
+  $('tabSettingsStatus').textContent = '';
+}
+
+function openTabSettings(): void {
+  renderTabSettingsOptions();
+  const popover = $('tabSettingsPopover') as HTMLFormElement;
+  popover.hidden = false;
+  $('tabSettingsToggle').setAttribute('aria-expanded', 'true');
+  $('tabSettingsStatus').textContent = '';
+  window.requestAnimationFrame(() => popover.querySelector<HTMLInputElement>('input')?.focus());
+}
+
+$('tabSettingsToggle').onclick = () => {
+  const popover = $('tabSettingsPopover') as HTMLFormElement;
+  if (popover.hidden) openTabSettings(); else closeTabSettings();
+};
+$('tabSettingsClose').onclick = closeTabSettings;
+$('tabSettingsReset').onclick = () => {
+  document.querySelectorAll<HTMLInputElement>('#tabSettingsOptions input').forEach((input) => {
+    input.checked = input.dataset.kind === 'tab';
+  });
+  $('tabSettingsStatus').textContent = '';
+};
+($('tabSettingsPopover') as HTMLFormElement).onsubmit = async (event: SubmitEvent) => {
+  event.preventDefault();
+  const inputs = Array.from(document.querySelectorAll<HTMLInputElement>('#tabSettingsOptions input'));
+  if (!inputs.some((input) => input.checked)) {
+    $('tabSettingsStatus').textContent = 'Choose at least one tab.';
+    return;
+  }
+  const hiddenTabs = inputs
+    .filter((input) => input.dataset.kind === 'tab' && !input.checked)
+    .map((input) => input.dataset.value || '').filter(Boolean);
+  const folders = inputs
+    .filter((input) => input.dataset.kind === 'folder' && input.checked)
+    .map((input) => input.dataset.value || '').filter(Boolean);
+  const save = $('tabSettingsSave') as HTMLButtonElement;
+  const expectedEpoch = vaultEpoch;
+  save.disabled = true;
+  save.textContent = 'Saving…';
+  $('tabSettingsStatus').textContent = '';
+  try {
+    await M.updateTabPreferences({ hiddenTabs, folders });
+    if (expectedEpoch !== vaultEpoch) return;
+    await loadAppConfig(expectedEpoch);
+    if (expectedEpoch !== vaultEpoch) return;
+    if (!visibleTab(state.tab)) switchTab(firstVisibleTab() || 'dashboard');
+    else setActiveTab(state.tab);
+    closeTabSettings();
+  } catch (error) {
+    $('tabSettingsStatus').textContent = String((error as Error)?.message || 'Could not save tabs');
+  } finally {
+    save.disabled = false;
+    save.textContent = 'Done';
+  }
+};
+document.addEventListener('click', (event) => {
+  const settings = $('tabSettings');
+  if (!(event.target instanceof Node) || settings.contains(event.target)) return;
+  closeTabSettings();
+});
+window.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !($('tabSettingsPopover') as HTMLFormElement).hidden) closeTabSettings();
+});
 
 $('vaultSwitch').onclick = () => { $('onboard').classList.toggle('dismissible', !!state.vault); $('onboard').style.display = 'grid'; initOnboarding(); };
 // The switcher overlays a working vault — always let the user back out without re-opening.
@@ -341,10 +510,12 @@ const chatEmptyTemplate = document.getElementById('chatEmpty')?.cloneNode(true) 
 
 function resetVaultScopedUi(): void {
   resetVaultUiModel(state);
+  closeTabSettings();
   clearThinking();
   currentArtifact = null;
   liveQuickNote = null;
   document.querySelectorAll('.tab[data-custom="1"], .chip[data-custom="1"]').forEach((element) => element.remove());
+  document.querySelectorAll<HTMLElement>('.tab[data-builtin="1"]').forEach((button) => { button.style.display = ''; });
   $('artifactTab').style.display = 'none';
   $('panelBody').replaceChildren();
   chatScroll.replaceChildren(...(chatEmptyTemplate ? [chatEmptyTemplate.cloneNode(true)] : []));
@@ -1242,7 +1413,7 @@ M.onFsChanged(({ area }) => {
       await loadAppConfig(epoch);
       if (epoch !== vaultEpoch || vaultOpening) return;
       // rebuilding the tab bar wipes the active class — and the active tab itself may be gone
-      if (!document.querySelector(`.tab[data-tab="${CSS.escape(state.tab)}"]`)) return switchTab('dashboard');
+      if (!visibleTab(state.tab)) return switchTab(firstVisibleTab() || 'dashboard');
       setActiveTab(state.tab);
     }
     const cdef = state.customTabs.find((t) => t.id === state.tab);

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -259,6 +259,43 @@ body {
 .tab-artifact { color: var(--accent-2); }
 .tab-custom::before { content: "＋"; font-size: 10px; color: var(--ink-faint); margin-right: 5px; vertical-align: 1px; }
 .tab-custom.active::before { color: var(--accent); }
+.tab-folder::before { content: "◇"; font-size: 11px; color: var(--ink-faint); margin-right: 5px; vertical-align: 1px; }
+.tab-folder.active::before { color: var(--accent); }
+
+.tab-settings { position: relative; flex: 0 0 auto; display: flex; align-items: center; padding: 5px 12px 0 2px; }
+.tab-settings-toggle {
+  width: 30px; height: 30px; border-radius: 8px; border: 1px solid transparent;
+  background: transparent; color: var(--ink-faint); display: grid; place-items: center; cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.tab-settings-toggle:hover, .tab-settings-toggle[aria-expanded="true"] { background: var(--panel); color: var(--ink); border-color: var(--line); }
+.tab-settings-toggle svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+.tab-settings-popover {
+  position: absolute; z-index: 50; top: calc(100% + 7px); right: 12px; width: min(390px, calc(100vw - 34px));
+  max-height: min(610px, calc(100vh - 110px)); background: var(--bg-2); border: 1px solid var(--line);
+  border-radius: 13px; box-shadow: 0 18px 50px rgba(0,0,0,.42); overflow: hidden;
+}
+.tab-settings-popover[hidden] { display: none; }
+.tab-settings-head { display: flex; align-items: flex-start; gap: 12px; padding: 15px 16px 13px; border-bottom: 1px solid var(--line); }
+.tab-settings-head > div { flex: 1; min-width: 0; }
+.tab-settings-head strong { display: block; color: var(--ink); font: 600 15px var(--font-ui); }
+.tab-settings-head span { display: block; color: var(--ink-faint); font: 11.5px/1.4 var(--font-ui); margin-top: 3px; }
+.tab-settings-close { border: 0; background: transparent; color: var(--ink-faint); cursor: pointer; font-size: 21px; line-height: 18px; padding: 0 2px; }
+.tab-settings-close:hover { color: var(--ink); }
+.tab-settings-options { padding: 6px 8px 10px; overflow-y: auto; max-height: min(490px, calc(100vh - 225px)); }
+.tab-settings-group-title { color: var(--ink-faint); font: 10px var(--font-mono); letter-spacing: .1em; text-transform: uppercase; padding: 10px 8px 5px; }
+.tab-settings-option { display: grid; grid-template-columns: 18px minmax(0, 1fr); column-gap: 8px; padding: 7px 8px; border-radius: 8px; cursor: pointer; }
+.tab-settings-option:hover { background: var(--panel); }
+.tab-settings-option input { margin: 2px 0 0; accent-color: var(--accent); }
+.tab-settings-option-main { min-width: 0; }
+.tab-settings-option-name { display: block; color: var(--ink-dim); font: 12.5px var(--font-ui); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tab-settings-option input:checked + .tab-settings-option-main .tab-settings-option-name { color: var(--ink); }
+.tab-settings-option-path { display: block; color: var(--ink-faint); font: 10.5px var(--font-mono); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tab-settings-empty { color: var(--ink-faint); font: 12px/1.5 var(--font-ui); padding: 8px; }
+.tab-settings-foot { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-top: 1px solid var(--line); }
+.tab-settings-reset { border: 0; background: transparent; color: var(--ink-faint); font: 11.5px var(--font-ui); cursor: pointer; padding: 5px 2px; }
+.tab-settings-reset:hover { color: var(--ink); }
+.tab-settings-status { flex: 1; color: var(--rose); font: 10.5px var(--font-ui); text-align: right; }
 
 .panel-body { flex: 1 1 auto; overflow-y: auto; padding: 20px; }
 

--- a/app/src/shared/types.d.ts
+++ b/app/src/shared/types.d.ts
@@ -70,7 +70,12 @@ interface TabDef {
   empty: string;
 }
 interface ChipDef { label: string; prompt: string; }
-interface AppConfig { tabs: TabDef[]; chips: ChipDef[]; }
+interface TabPreferenceUpdate { hiddenTabs: string[]; folders: string[]; }
+interface AppConfig extends TabPreferenceUpdate {
+  tabs: TabDef[];
+  chips: ChipDef[];
+  availableFolders: string[];
+}
 
 // ---------- vault search ----------
 interface SearchHit { rel: string; title: string; ext: string; snippet?: string; }
@@ -194,6 +199,7 @@ interface MemexApi {
   data(kind: 'inbox' | 'outputs'): Promise<FileEntry[] | null>;
   data(kind: DataKind): Promise<unknown>;
   appConfig(): Promise<AppConfig | null>;
+  updateTabPreferences(preferences: TabPreferenceUpdate): Promise<AppConfig>;
   search(q: string): Promise<SearchResults>;
   tabContent(p: string): Promise<TabContentResult>;
   tabQuery(def: TabDef): Promise<TabQueryResult>;

--- a/app/src/shared/vault-ui-state.ts
+++ b/app/src/shared/vault-ui-state.ts
@@ -7,7 +7,11 @@ interface ResettableVaultUiState {
   history: unknown[];
   histPos: number;
   customTabs: unknown[];
+  configuredTabs: unknown[];
   customChips: unknown[];
+  hiddenTabs: string[];
+  selectedFolders: string[];
+  availableFolders: string[];
 }
 
 interface VaultOpenEpochState {
@@ -38,5 +42,9 @@ function resetVaultUiModel(state: ResettableVaultUiState): void {
   state.history = [];
   state.histPos = -1;
   state.customTabs = [];
+  state.configuredTabs = [];
   state.customChips = [];
+  state.hiddenTabs = [];
+  state.selectedFolders = [];
+  state.availableFolders = [];
 }

--- a/app/src/shared/vault-ui-state.ts
+++ b/app/src/shared/vault-ui-state.ts
@@ -19,6 +19,17 @@ interface VaultOpenEpochState {
   epoch: number;
 }
 
+interface VisibleTabCandidate {
+  tab: string;
+  visible: boolean;
+  artifact: boolean;
+}
+
+/** Pick the first user-configured visible tab, never the transient artifact tab. */
+function selectFirstVisibleTab(candidates: readonly VisibleTabCandidate[]): string | null {
+  return candidates.find((candidate) => candidate.visible && !candidate.artifact)?.tab || null;
+}
+
 /** Start an open attempt without invalidating work belonging to the committed vault. */
 function beginVaultOpen(state: VaultOpenEpochState): number {
   state.request += 1;

--- a/app/test/tab-preferences.test.cjs
+++ b/app/test/tab-preferences.test.cjs
@@ -5,6 +5,8 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+  CONFIGURABLE_BUILTIN_TAB_IDS,
+  isReservedDesktopTabId,
   parseDesktopTabsDocument,
   tabPreferencesFromDocument,
   withTabPreferences,
@@ -42,6 +44,15 @@ test('tab preferences are validated, deduplicated, and preserve unrelated deskto
   assert.deepEqual(updated.tabs, original.tabs);
   assert.deepEqual(updated.chips, original.chips);
   assert.deepEqual(updated.futureSetting, { keep: true });
+});
+
+test('renderer-owned and generated tab IDs remain reserved from custom tabs', () => {
+  for (const id of [...CONFIGURABLE_BUILTIN_TAB_IDS, 'artifact']) {
+    assert.equal(isReservedDesktopTabId(id), true, `${id} should be reserved`);
+    assert.equal(isReservedDesktopTabId(id.toUpperCase()), true, `${id} should be reserved case-insensitively`);
+  }
+  assert.equal(isReservedDesktopTabId('folder:Atlas/Areas'), true);
+  assert.equal(isReservedDesktopTabId('cv'), false);
 });
 
 test('hand-edited preferences cannot hide every available tab without selecting a folder', () => {

--- a/app/test/tab-preferences.test.cjs
+++ b/app/test/tab-preferences.test.cjs
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  parseDesktopTabsDocument,
+  tabPreferencesFromDocument,
+  withTabPreferences,
+  writeDesktopTabsDocument,
+} = require('../dist/main/tab-preferences.js');
+
+function makeVault(t) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'memex-tab-prefs-'));
+  fs.writeFileSync(path.join(vault, 'AGENTS.md'), '# Vault\n');
+  fs.mkdirSync(path.join(vault, 'Atlas/Areas'), { recursive: true });
+  fs.mkdirSync(path.join(vault, 'Ops/Tasks'), { recursive: true });
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return vault;
+}
+
+test('tab preferences are validated, deduplicated, and preserve unrelated desktop config', () => {
+  const original = parseDesktopTabsDocument(JSON.stringify({
+    tabs: [{ id: 'cv', label: 'CV', path: 'CV' }],
+    chips: [{ label: 'Review', prompt: 'Review this week' }],
+    futureSetting: { keep: true },
+    navigation: { hidden: ['people'], folders: ['Atlas/Areas'], futureNavigationSetting: true },
+  }));
+  assert.deepEqual(
+    tabPreferencesFromDocument(original, ['dashboard', 'people', 'cv'], ['Atlas/Areas']),
+    { hiddenTabs: ['people'], folders: ['Atlas/Areas'] },
+  );
+
+  const updated = withTabPreferences(
+    original,
+    { hiddenTabs: ['dashboard', 'dashboard', 'unknown'], folders: ['Atlas/Areas', '../escape', 'Atlas/Areas'] },
+    ['dashboard', 'people', 'cv'],
+    ['Atlas/Areas'],
+  );
+  assert.deepEqual(updated.navigation, { hidden: ['dashboard'], folders: ['Atlas/Areas'], futureNavigationSetting: true });
+  assert.deepEqual(updated.tabs, original.tabs);
+  assert.deepEqual(updated.chips, original.chips);
+  assert.deepEqual(updated.futureSetting, { keep: true });
+});
+
+test('hand-edited preferences cannot hide every available tab without selecting a folder', () => {
+  assert.deepEqual(
+    tabPreferencesFromDocument(
+      { navigation: { hidden: ['dashboard', 'people'], folders: [] } },
+      ['dashboard', 'people'],
+      ['Atlas/Areas'],
+    ),
+    { hiddenTabs: ['people'], folders: [] },
+  );
+  assert.deepEqual(
+    tabPreferencesFromDocument(
+      { navigation: { hidden: ['dashboard', 'people'], folders: ['Atlas/Areas'] } },
+      ['dashboard', 'people'],
+      ['Atlas/Areas'],
+    ),
+    { hiddenTabs: ['dashboard', 'people'], folders: ['Atlas/Areas'] },
+  );
+});
+
+test('desktop tab preferences write to the vault config without dropping existing fields', (t) => {
+  const vault = makeVault(t);
+  const document = { tabs: [{ label: 'CV', path: 'CV' }], navigation: { hidden: ['ideas'], folders: ['Atlas/Areas'] } };
+  assert.equal(writeDesktopTabsDocument(vault, document), true);
+  const saved = JSON.parse(fs.readFileSync(path.join(vault, '_config/desktop-tabs.json'), 'utf8'));
+  assert.deepEqual(saved, document);
+  assert.equal(fs.statSync(path.join(vault, '_config/desktop-tabs.json')).isFile(), true);
+  assert.equal(writeDesktopTabsDocument(vault, document), false);
+});
+
+test('desktop tab preference writes reject an unsafe config directory symlink', (t) => {
+  const vault = makeVault(t);
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'memex-tab-prefs-outside-'));
+  t.after(() => fs.rmSync(outside, { recursive: true, force: true }));
+  try {
+    fs.symlinkSync(outside, path.join(vault, '_config'), process.platform === 'win32' ? 'junction' : 'dir');
+  } catch (error) {
+    if (error && (error.code === 'EPERM' || error.code === 'EACCES')) {
+      t.skip('symbolic links are not permitted on this platform');
+      return;
+    }
+    throw error;
+  }
+  assert.throws(() => writeDesktopTabsDocument(vault, { navigation: {} }), /unsafe/);
+  assert.equal(fs.existsSync(path.join(outside, 'desktop-tabs.json')), false);
+});

--- a/app/test/vault-ui-state.test.cjs
+++ b/app/test/vault-ui-state.test.cjs
@@ -53,3 +53,29 @@ test('a failed vault-open request does not advance the committed vault epoch', (
   assert.equal(result.committedEpoch, 8);
   assert.equal(result.state.epoch, 8);
 });
+
+test('visible tab fallback skips hidden tabs and the transient artifact tab', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../dist/shared/vault-ui-state.js'), 'utf8');
+  const context = vm.createContext({});
+  vm.runInContext(source, context);
+  const result = vm.runInContext(`selectFirstVisibleTab([
+    { tab: 'dashboard', visible: false, artifact: false },
+    { tab: 'artifact', visible: true, artifact: true },
+    { tab: 'tasks', visible: true, artifact: false },
+    { tab: 'projects', visible: true, artifact: false },
+  ])`, context);
+
+  assert.equal(result, 'tasks');
+});
+
+test('visible tab fallback returns null when no persistent tab is visible', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../dist/shared/vault-ui-state.js'), 'utf8');
+  const context = vm.createContext({});
+  vm.runInContext(source, context);
+  const result = vm.runInContext(`selectFirstVisibleTab([
+    { tab: 'dashboard', visible: false, artifact: false },
+    { tab: 'artifact', visible: true, artifact: true },
+  ])`, context);
+
+  assert.equal(result, null);
+});

--- a/app/test/vault-ui-state.test.cjs
+++ b/app/test/vault-ui-state.test.cjs
@@ -12,7 +12,8 @@ test('vault UI reset clears all session-scoped model state', () => {
     const state = {
       tab: 'artifact', activeAssistant: { raw: 'old vault' },
       toolCards: new Map([['old', {}]]), busy: true, hasArtifact: true,
-      history: [{ k: 'art' }], histPos: 0, customTabs: [{}], customChips: [{}],
+      history: [{ k: 'art' }], histPos: 0, customTabs: [{}], configuredTabs: [{}], customChips: [{}],
+      hiddenTabs: ['people'], selectedFolders: ['Atlas/Areas'], availableFolders: ['Atlas/Areas'],
     };
     resetVaultUiModel(state);
     return { ...state, toolCardCount: state.toolCards.size };
@@ -26,7 +27,11 @@ test('vault UI reset clears all session-scoped model state', () => {
   assert.deepEqual(Array.from(result.history), []);
   assert.equal(result.histPos, -1);
   assert.deepEqual(Array.from(result.customTabs), []);
+  assert.deepEqual(Array.from(result.configuredTabs), []);
   assert.deepEqual(Array.from(result.customChips), []);
+  assert.deepEqual(Array.from(result.hiddenTabs), []);
+  assert.deepEqual(Array.from(result.selectedFolders), []);
+  assert.deepEqual(Array.from(result.availableFolders), []);
 });
 
 test('a failed vault-open request does not advance the committed vault epoch', () => {

--- a/app/test/vault.test.cjs
+++ b/app/test/vault.test.cjs
@@ -90,3 +90,26 @@ test('vault collection content budgets are cumulative', () => {
   assert.equal(budget.take(4), true);
   assert.equal(budget.take(1), false);
 });
+
+test('folder discovery returns nested content folders but not hidden or configuration trees', (t) => {
+  const { vault, outside } = makeTree(t);
+  fs.mkdirSync(path.join(vault, 'Agents/Prompts'), { recursive: true });
+  fs.mkdirSync(path.join(vault, 'Atlas/Areas'), { recursive: true });
+  fs.mkdirSync(path.join(vault, '_config/private'), { recursive: true });
+  fs.mkdirSync(path.join(vault, '.living/private'), { recursive: true });
+  fs.mkdirSync(path.join(vault, 'node_modules/private'), { recursive: true });
+  try {
+    fs.symlinkSync(outside, path.join(vault, 'Linked'), process.platform === 'win32' ? 'junction' : 'dir');
+  } catch (error) {
+    if (!error || (error.code !== 'EPERM' && error.code !== 'EACCES')) throw error;
+  }
+
+  const folders = vaultLib.listFolders(vault);
+  assert.equal(folders.includes('Agents'), true);
+  assert.equal(folders.includes('Agents/Prompts'), true);
+  assert.equal(folders.includes('Atlas/Areas'), true);
+  assert.equal(folders.some((folder) => folder.startsWith('_config')), false);
+  assert.equal(folders.some((folder) => folder.startsWith('.living')), false);
+  assert.equal(folders.some((folder) => folder.startsWith('node_modules')), false);
+  assert.equal(folders.includes('Linked'), false);
+});


### PR DESCRIPTION
Closes #33

## What changed

- keep the curated high-frequency desktop tabs as the default
- add a gear menu with checkbox controls for built-in and existing custom tabs
- discover safe nested vault folders and let users add them as browsable path tabs
- persist visibility and folder choices per vault in `_config/desktop-tabs.json`
- preserve existing tabs, chips, navigation fields, and unknown config fields
- document the new picker and config shape

## Why

The desktop app intentionally exposed a compact set of common note types, but there was no UI path to less common folders such as Areas, Concepts, Decisions, Briefings, or Agents/Prompts. Users had to create custom JSON tabs individually.

## Review fixes

A follow-up code review also hardened three edge cases:

- hand-edited config can no longer hide every available tab and strand the panel
- older vaults that lacked `_config/` attach a fallback watcher after the picker creates it
- the in-app agent prompt explicitly preserves gear-menu navigation preferences when editing custom tabs

Folder discovery excludes hidden/configuration trees and unsafe symlinks, and preference writes use a validated atomic replacement.

## Validation

- `npm test` — 72 tests passed
- browser-tested hiding Ideas; adding Agents/Prompts, Atlas/Areas, and Ops/Briefings; reopening the picker to confirm persisted state; and browsing the selected Areas folder
- browser console clean
- manually confirmed the development Memex workflow