### PR TITLE
Guard tracker propose-only history contract

### DIFF
--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -227,6 +227,14 @@ class TestTrackerHistoryContract(unittest.TestCase):
                     r"(?is)last_digest.{0,160}state.{0,160}# History.{0,160}provenance",
                 )
 
+    def test_propose_only_history_names_the_required_review_task(self):
+        history_step = self.run_surfaces["skill"]
+        self.assertRegex(
+            history_step,
+            r"(?is)auto_update_wiki.{0,160}false.{0,160}needs-review Task",
+        )
+        self.assertNotIn("no Tasks created", history_step)
+
     def test_specialized_runner_allows_digest_and_history_outputs(self):
         self.assertIn("Tracker Digest", self.cv_output_contract)
         self.assertIn("# History", self.cv_output_contract)

--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -229,19 +229,22 @@ class TestTrackerHistoryContract(unittest.TestCase):
 
     def test_propose_only_history_names_the_required_review_task(self):
         history_step = self.run_surfaces["skill"]
-        self.assertRegex(
-            history_step,
-            r"(?is)auto_update_wiki.{0,160}false.{0,160}"
+        affirmative_task_creation = (
+            r"(?is)auto_update_wiki.{0,80}\bfalse\b[)`]*\s*"
+            r"(?:[,;:—-]\s*)?"
             r"(?:(?:create|write) a needs-review Task|"
-            r"name the needs-review Task (?:that was )?created)",
+            r"name the needs-review Task (?:that was )?created)"
         )
-        self.assertNotRegex(
-            history_step,
-            r"(?is)auto_update_wiki.{0,160}false.{0,160}"
-            r"(?:(?:do not|don't|never|without|skip|omit).{0,80}"
-            r"(?:create|write|name).{0,80}(?:needs-review )?Tasks?|"
-            r"no (?:needs-review )?Tasks?(?: (?:created|written|named))?)",
+        self.assertRegex(history_step, affirmative_task_creation)
+
+        contradictory_guidance = (
+            "auto_update_wiki: false — do not create a needs-review Task",
+            "auto_update_wiki: false — must not create a needs-review Task",
+            "auto_update_wiki: false — no need to create a needs-review Task",
         )
+        for guidance in contradictory_guidance:
+            with self.subTest(guidance=guidance):
+                self.assertNotRegex(guidance, affirmative_task_creation)
 
     def test_specialized_runner_allows_digest_and_history_outputs(self):
         self.assertIn("Tracker Digest", self.cv_output_contract)

--- a/tools/test_skill_contracts.py
+++ b/tools/test_skill_contracts.py
@@ -231,9 +231,17 @@ class TestTrackerHistoryContract(unittest.TestCase):
         history_step = self.run_surfaces["skill"]
         self.assertRegex(
             history_step,
-            r"(?is)auto_update_wiki.{0,160}false.{0,160}needs-review Task",
+            r"(?is)auto_update_wiki.{0,160}false.{0,160}"
+            r"(?:(?:create|write) a needs-review Task|"
+            r"name the needs-review Task (?:that was )?created)",
         )
-        self.assertNotIn("no Tasks created", history_step)
+        self.assertNotRegex(
+            history_step,
+            r"(?is)auto_update_wiki.{0,160}false.{0,160}"
+            r"(?:(?:do not|don't|never|without|skip|omit).{0,80}"
+            r"(?:create|write|name).{0,80}(?:needs-review )?Tasks?|"
+            r"no (?:needs-review )?Tasks?(?: (?:created|written|named))?)",
+        )
 
     def test_specialized_runner_allows_digest_and_history_outputs(self):
         self.assertIn("Tracker Digest", self.cv_output_contract)


### PR DESCRIPTION
## What changed

- Add a contract regression test for the `run-trackers` history step.
- Require `auto_update_wiki: false` history guidance to name the needs-review Task created for the proposed edit.
- Explicitly reject the contradictory `no Tasks created` wording found during review of #35.

## Why

PR #44 already merged the tracker-history behavior and broader contract coverage, so PR #35 was closed as superseded. One specific contradiction from #35 was not directly covered: propose-only runs still create a needs-review Task under the canonical update-target procedure. This test prevents that guidance from drifting again.

## Impact

Test-only change; runtime and installed-vault behavior are unchanged.

## Validation

- `python3 -m unittest test_skill_contracts.TestTrackerHistoryContract.test_propose_only_history_names_the_required_review_task`
- `python3 -m unittest` (69 tests)
- `git diff --check`