### PR TITLE
ci: upgrade GitHub Actions to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       # context is not available in step-level `if` expressions.
       APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -80,8 +80,8 @@ jobs:
     # AZURE_* secrets below.
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -98,8 +98,8 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

- upgrade all release jobs from `actions/checkout@v4` to `actions/checkout@v7`
- upgrade all release jobs from `actions/setup-node@v4` to `actions/setup-node@v7`
- retain Node.js 22 and the existing explicit npm cache configuration

## Why

The 0.1.7 release succeeded, but GitHub warned that the v4 actions target the deprecated Node 20 action runtime and had to be forced onto Node 24. Both official v7 actions run natively on Node 24.

The latest release used hosted runner `2.336.0`, which satisfies checkout's `2.329.0` minimum for modern credential storage and its `2.327.1` minimum for Node 24 actions.

## Impact

Release behavior is unchanged. The workflow continues to build on macOS, Windows, and Linux with Node.js 22, while removing the action-runtime deprecation warning and picking up the current action security fixes.

## Validation

- workflow YAML parsed successfully
- `git diff --check` passed
- all six action references resolve to v7
- [non-publishing three-platform rehearsal](https://github.com/arjunrajlaboratory/Memex/actions/runs/31588678296) passed:
  - macOS — 11m06s
  - Windows — 4m05s
  - Linux — 2m46s
- no release assets were uploaded
