### PR TITLE
update: don't ship Quartz build state; feed git path lists over stdin

### DIFF
--- a/tools/memex_bake.py
+++ b/tools/memex_bake.py
@@ -210,6 +210,18 @@ def bake_file(src: pathlib.Path, dst: pathlib.Path, answers: dict[str, Any], nor
         shutil.copy2(src, dst)
 
 
+# Local build state that `npm install` / `quartz build` leave inside
+# hardened/quartz when someone runs the engine's own Quartz. These directories
+# are gitignored there (hardened/quartz/.gitignore) but a raw rglob still sees
+# them; shipping them baked ~18k npm files into one vault's plan and manifest.
+QUARTZ_BUILD_ARTIFACT_DIRS = frozenset({"node_modules", "public", ".quartz-cache", "prof"})
+
+
+def quartz_shippable(rel: pathlib.Path) -> bool:
+    """True if a file under hardened/quartz is engine content, not build state."""
+    return bool(rel.parts) and rel.parts[0] not in QUARTZ_BUILD_ARTIFACT_DIRS and rel.name != ".DS_Store"
+
+
 def bake_tree(src: pathlib.Path, dst: pathlib.Path, answers: dict[str, Any], result: BakeResult | None = None, pack: str | None = None, normalized: dict[str, str] | None = None) -> None:
     normalized = normalized if normalized is not None else normalize_answers(answers)
     for fp in src.rglob("*"):
@@ -577,7 +589,7 @@ def bake_engine(
     quartz = engine_dir / "hardened/quartz"
     if quartz.exists():
         for fp in quartz.rglob("*"):
-            if fp.is_file():
+            if fp.is_file() and quartz_shippable(fp.relative_to(quartz)):
                 dst = target / "quartz" / fp.relative_to(quartz)
                 bake_file(fp, dst, answers, normalized)
                 result.record(dst.relative_to(target), "hardened", fp)

--- a/tools/memex_update.py
+++ b/tools/memex_update.py
@@ -598,17 +598,25 @@ def filter_unignored(vault_dir: pathlib.Path, paths: set[str] | list[str]) -> li
     return [p for p in items if p not in ignored]
 
 
+def tracked_paths(vault_dir: pathlib.Path, paths: set[str] | list[str]) -> list[str]:
+    """The subset of `paths` git currently tracks, in sorted order.
+
+    `git ls-files` has no --pathspec-from-file, so rather than splatting the
+    candidates into argv (ARG_MAX) list the whole index once and intersect."""
+    wanted = set(paths)
+    if not wanted:
+        return []
+    out = run_git(vault_dir, ["ls-files", "-z"], check=False).stdout
+    tracked = {entry for entry in out.split("\0") if entry}
+    return sorted(wanted & tracked)
+
+
 def commit_update(vault_dir: pathlib.Path, version: str, paths: set[str] | None = None) -> bool:
     if paths:
         unignored = filter_unignored(vault_dir, paths)
         existing = [p for p in unignored if (vault_dir / p).exists()]
         missing = [p for p in unignored if not (vault_dir / p).exists()]
-        tracked_missing: list[str] = []
-        if missing:
-            # One batched ls-files call instead of one subprocess per path.
-            out = run_git(vault_dir, ["ls-files", "--", *missing], check=False)
-            tracked = {line for line in out.stdout.splitlines() if line}
-            tracked_missing = [p for p in missing if p in tracked]
+        tracked_missing = tracked_paths(vault_dir, missing) if missing else []
         addable = existing + tracked_missing
         if addable:
             run_git(
@@ -1554,13 +1562,14 @@ def abort_update(args: argparse.Namespace) -> int:
     previous = plan.get("previous_branch")
 
     # Revert tracked files the update modified/deleted back to their committed state.
-    tracked = [
-        line
-        for line in run_git(vault_dir, ["ls-files", "--", *sorted(paths)], check=False).stdout.splitlines()
-        if line
-    ]
+    tracked = tracked_paths(vault_dir, paths)
     if tracked:
-        run_git(vault_dir, ["restore", "--source=HEAD", "--staged", "--worktree", "--", *tracked], check=False)
+        run_git(
+            vault_dir,
+            ["restore", "--source=HEAD", "--staged", "--worktree", "--pathspec-from-file=-"],
+            check=False,
+            input="".join(f"{p}\n" for p in tracked),
+        )
     # untrack_memex_state stages a .memex deletion; ls-files above no longer
     # sees those paths, so re-stage them from HEAD explicitly. On vaults that
     # never tracked .memex this is a no-op (next prepare untracks again).

--- a/tools/memex_update.py
+++ b/tools/memex_update.py
@@ -483,7 +483,13 @@ def add_version_paths(
     entry["staged_path"] = staged_version_path(work_dir, "staged", rel, staged_dir / rel)
 
 
-def run_git(vault_dir: pathlib.Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run_git(
+    vault_dir: pathlib.Path,
+    args: list[str],
+    *,
+    check: bool = True,
+    input: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         # quotepath off so non-ASCII paths come back verbatim, not octal-escaped
         ["git", "-c", "core.quotepath=off", *args],
@@ -491,6 +497,7 @@ def run_git(vault_dir: pathlib.Path, args: list[str], *, check: bool = True) -> 
         text=True,
         capture_output=True,
         check=check,
+        input=input,
     )
 
 
@@ -579,7 +586,14 @@ def filter_unignored(vault_dir: pathlib.Path, paths: set[str] | list[str]) -> li
     items = sorted(paths)
     if not items:
         return []
-    proc = run_git(vault_dir, ["check-ignore", "--", *items], check=False)
+    # Paths go over stdin: a plan can name tens of thousands of files, and
+    # passing them as argv exceeds ARG_MAX (OSError: Argument list too long).
+    proc = run_git(
+        vault_dir,
+        ["check-ignore", "--stdin"],
+        check=False,
+        input="".join(f"{p}\n" for p in items),
+    )
     ignored = {line for line in proc.stdout.splitlines() if line}
     return [p for p in items if p not in ignored]
 
@@ -597,7 +611,11 @@ def commit_update(vault_dir: pathlib.Path, version: str, paths: set[str] | None 
             tracked_missing = [p for p in missing if p in tracked]
         addable = existing + tracked_missing
         if addable:
-            run_git(vault_dir, ["add", "--", *addable])
+            run_git(
+                vault_dir,
+                ["add", "--pathspec-from-file=-"],
+                input="".join(f"{p}\n" for p in addable),
+            )
     else:
         run_git(vault_dir, ["add", "."])
     diff = run_git(vault_dir, ["diff", "--cached", "--quiet"], check=False)

--- a/tools/test_memex_update.py
+++ b/tools/test_memex_update.py
@@ -622,5 +622,56 @@ class TestPlanResolution(unittest.TestCase):
             self.assertTrue((work / "undo" / "sentinel").exists())
 
 
+class QuartzBuildArtifactTests(unittest.TestCase):
+    def test_quartz_shippable_skips_build_state(self):
+        from memex_bake import quartz_shippable
+
+        self.assertTrue(quartz_shippable(pathlib.Path("quartz.config.ts")))
+        self.assertTrue(quartz_shippable(pathlib.Path("quartz/plugins/emitters/x.ts")))
+        # Deliberately shipped even though hardened/quartz/.gitignore lists them.
+        self.assertTrue(quartz_shippable(pathlib.Path("tsconfig.tsbuildinfo")))
+        self.assertTrue(quartz_shippable(pathlib.Path(".gitignore")))
+        for rel in ("node_modules/pixi.js/index.js", "public/index.html", ".quartz-cache/x", "prof/x", ".DS_Store"):
+            self.assertFalse(quartz_shippable(pathlib.Path(rel)), rel)
+
+    def test_bake_engine_does_not_ship_node_modules(self):
+        from memex_bake import bake_engine
+
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = pathlib.Path(tmp) / "engine"
+            (engine / "hardened/quartz/node_modules/pixi.js").mkdir(parents=True)
+            (engine / "hardened/quartz/node_modules/pixi.js/index.js").write_text("x")
+            (engine / "hardened/quartz/public").mkdir()
+            (engine / "hardened/quartz/public/index.html").write_text("x")
+            (engine / "hardened/quartz/quartz.config.ts").write_text("export default {}")
+            (engine / "VERSION").write_text("0.0.0\n")
+            (engine / "hardened/contract").mkdir(parents=True)
+            (engine / "hardened/contract/AGENTS.base.md").write_text("# Agents\n")
+            (engine / "hardened/contract/CLAUDE.base.md").write_text("# Claude\n")
+            target = pathlib.Path(tmp) / "target"
+            result = bake_engine(engine, target, {}, [], include_scaffold=False, include_seeds=False)
+            baked = {p.relative_to(target).as_posix() for p in target.rglob("*") if p.is_file()}
+            self.assertIn("quartz/quartz.config.ts", baked)
+            self.assertFalse({p for p in baked if p.startswith("quartz/node_modules/")})
+            self.assertFalse({p for p in baked if p.startswith("quartz/public/")})
+            recorded = {str(k) for k in result.files} if hasattr(result, "files") else set()
+            self.assertFalse({p for p in recorded if "node_modules" in p})
+
+
+class FilterUnignoredTests(unittest.TestCase):
+    def test_many_paths_do_not_overflow_argv(self):
+        import subprocess
+
+        from memex_update import filter_unignored
+
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = pathlib.Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
+            (vault / ".gitignore").write_text("quartz/node_modules/\n")
+            many = [f"quartz/node_modules/pkg-{i:05d}/lib/index.js" for i in range(30000)]
+            kept = filter_unignored(vault, {"AGENTS.md", ".gitignore", *many})
+            self.assertEqual(kept, [".gitignore", "AGENTS.md"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_memex_update.py
+++ b/tools/test_memex_update.py
@@ -654,8 +654,9 @@ class QuartzBuildArtifactTests(unittest.TestCase):
             self.assertIn("quartz/quartz.config.ts", baked)
             self.assertFalse({p for p in baked if p.startswith("quartz/node_modules/")})
             self.assertFalse({p for p in baked if p.startswith("quartz/public/")})
-            recorded = {str(k) for k in result.files} if hasattr(result, "files") else set()
-            self.assertFalse({p for p in recorded if "node_modules" in p})
+            recorded = set(result.files)
+            self.assertIn("quartz/quartz.config.ts", recorded)
+            self.assertFalse({p for p in recorded if p.startswith(("quartz/node_modules/", "quartz/public/"))})
 
 
 class FilterUnignoredTests(unittest.TestCase):
@@ -671,6 +672,21 @@ class FilterUnignoredTests(unittest.TestCase):
             many = [f"quartz/node_modules/pkg-{i:05d}/lib/index.js" for i in range(30000)]
             kept = filter_unignored(vault, {"AGENTS.md", ".gitignore", *many})
             self.assertEqual(kept, [".gitignore", "AGENTS.md"])
+
+    def test_tracked_paths_many_candidates(self):
+        import subprocess
+
+        from memex_update import tracked_paths
+
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = pathlib.Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
+            (vault / "AGENTS.md").write_text("x")
+            (vault / "CLAUDE.md").write_text("x")
+            subprocess.run(["git", "add", "AGENTS.md"], cwd=tmp, check=True)
+            many = [f"quartz/node_modules/pkg-{i:05d}/lib/index.js" for i in range(30000)]
+            self.assertEqual(tracked_paths(vault, {"AGENTS.md", "CLAUDE.md", "nope.md", *many}), ["AGENTS.md"])
+            self.assertEqual(tracked_paths(vault, set()), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #53.

## Summary
- `bake_engine` walked `hardened/quartz` with a raw `rglob`, so an untracked `node_modules/` left by running the engine's own Quartz was baked into a vault's update plan and manifest (~18k `collision` entries). New `quartz_shippable()` skips `node_modules/`, `public/`, `.quartz-cache/`, `prof/`, `.DS_Store`; the deliberately shipped `tsconfig.tsbuildinfo` and `.gitignore` still go out.
- `finalize` then crashed in `filter_unignored` with `OSError: Argument list too long` because every plan path went to `git check-ignore` as argv. `run_git` gains an `input=` kwarg; `check-ignore --stdin` and `add --pathspec-from-file=-` take the path list over stdin so plan size can never exceed `ARG_MAX`.

## Test plan
- [x] New tests: `quartz_shippable` allow/deny list; `bake_engine` on a fake engine with `node_modules/` + `public/` ships only `quartz.config.ts`; `filter_unignored` with 30k ignored paths returns only the two unignored ones
- [x] `python3 -m unittest test_memex_update test_memex_init` — 65 tests OK
- [x] Real run: finalized a 0.1.1 → 0.1.3 vault update against this commit; manifest went from 18,214 entries to 428, zero `node_modules`, update commit landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7Qt2Lc8FWkqzWS1ShPRnt